### PR TITLE
Update README to remove badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # PISP.jl: Julia parser of the Integrated System Plan
 
-[![Build Status](https://github.com/papablazad/PISP.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/papablazad/PISP.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/papablazad/PISP.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/papablazad/PISP.jl)
-
 **PISP** (short for *Julia Parser of the Integrated System Plan*) is an open-source toolkit for parsing and generating structured datasets of the East Coast Australian Power System for power system studies. 
 
 The data parsing functionalities are built on publicly available information from the Integrated System Plan (ISP) released by the Australian Energy Market Operator (AEMO) for the Australian National Electricity Market (NEM).


### PR DESCRIPTION
Remove build status and coverage badges from the README to streamline the documentation.