### PR TITLE
Add test source specs

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,5 @@ include("test_source_availability.jl")
     include("test_source_downloader_2026.jl")
     include("test_buildout_defaults_documentation_2024.jl")
     include("test_source_specs.jl")
+    include("test_pipeline_integration_2024.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,4 +16,5 @@ include("test_source_availability.jl")
     include("test_report_downloader_2026.jl")
     include("test_source_downloader_2026.jl")
     include("test_buildout_defaults_documentation_2024.jl")
+    include("test_source_specs.jl")
 end

--- a/test/test_pipeline_integration_2024.jl
+++ b/test/test_pipeline_integration_2024.jl
@@ -1,22 +1,16 @@
-# Integration characterization test for the 2024 populate stage: exercises
-# PISP.populate_time_static!/PISP.populate_time_varying! end-to-end against the real
-# local data/2024/pisp-downloads/ checkout, for one scenario and one short date window.
-# This is the call graph PISP.build_ISP24_datasets itself runs after the one-time
-# PISP.build_pipeline data-preparation step, so it reaches almost every function in
-# src/parsers/PISP-2024parser.jl, src/parsers/PISP-2024core.jl, src/parsers/PISP-2024ev.jl,
-# and the df-evs/df-hydro/general utils — the largest previously-0%-covered source files.
-# PISP.build_pipeline itself is deliberately never called here: it downloads/re-extracts
-# archives and regenerates Auxiliary/ outlook workbooks and 4006 traces in place, mutating
-# the real local checkout, which a test must never do. Skipped gracefully when the real
-# AEMO data is absent, since CI has no access to it.
+# Integration test for the 2024 data-population stage.
 #
-# Note: populate_time_static! -> generator_table creates a scratch test/.tmp/ directory
-# (relative to the process's working directory) with ~26 intermediate workbooks; this is
-# pre-existing src/ behaviour, not introduced here, and test/.tmp/ is already gitignored.
+# Runs `populate_time_static!` and `populate_time_varying!` end to end using the
+# real local AEMO data, one Step Change scenario, and one day of simulation.
+# This exercises the population stage used by `build_ISP24_datasets`.
 #
-# Takes noticeably longer than the rest of the suite (real workbook/CSV I/O). Set
-# PISP_SKIP_SLOW_TESTS=1 to skip it for a fast local inner loop; CI already skips it via
-# the data-presence check below, so this is purely a local dev convenience.
+# `build_pipeline` is not run because it rebuilds and modifies the local data.
+# 
+# The test is skipped when the data is unavailable or `PISP_SKIP_SLOW_TESTS=1`.
+#
+# Note: populate_time_static! -> generator_table creates a scratch test/.tmp/
+# (gitignored)directory (relative to the process's working directory) with ~26
+# intermediate workbooks. This is pre-existing PISP.jl/src behaviour.
 
 using DataFrames
 using Dates

--- a/test/test_pipeline_integration_2024.jl
+++ b/test/test_pipeline_integration_2024.jl
@@ -1,0 +1,113 @@
+# Integration characterization test for the 2024 populate stage: exercises
+# PISP.populate_time_static!/PISP.populate_time_varying! end-to-end against the real
+# local data/2024/pisp-downloads/ checkout, for one scenario and one short date window.
+# This is the call graph PISP.build_ISP24_datasets itself runs after the one-time
+# PISP.build_pipeline data-preparation step, so it reaches almost every function in
+# src/parsers/PISP-2024parser.jl, src/parsers/PISP-2024core.jl, src/parsers/PISP-2024ev.jl,
+# and the df-evs/df-hydro/general utils — the largest previously-0%-covered source files.
+# PISP.build_pipeline itself is deliberately never called here: it downloads/re-extracts
+# archives and regenerates Auxiliary/ outlook workbooks and 4006 traces in place, mutating
+# the real local checkout, which a test must never do. Skipped gracefully when the real
+# AEMO data is absent, since CI has no access to it.
+#
+# Note: populate_time_static! -> generator_table creates a scratch test/.tmp/ directory
+# (relative to the process's working directory) with ~26 intermediate workbooks; this is
+# pre-existing src/ behaviour, not introduced here, and test/.tmp/ is already gitignored.
+#
+# Takes noticeably longer than the rest of the suite (real workbook/CSV I/O). Set
+# PISP_SKIP_SLOW_TESTS=1 to skip it for a fast local inner loop; CI already skips it via
+# the data-presence check below, so this is purely a local dev convenience.
+
+using DataFrames
+using Dates
+
+pipeline_integration_2024_edition = only(filter(
+    p -> p.edition == "2024",
+    source_availability_profiles(normpath(joinpath(@__DIR__, ".."))),
+))
+pipeline_integration_2024_available = inspect_edition(pipeline_integration_2024_edition).state == :complete
+pipeline_integration_2024_skip_slow = get(ENV, "PISP_SKIP_SLOW_TESTS", "") == "1"
+
+@testset "pipeline integration: populate_time_static!/populate_time_varying! (2024, Step Change, one day)" begin
+    if pipeline_integration_2024_skip_slow
+        @test_skip "PISP_SKIP_SLOW_TESTS=1; skipping the slow real-data pipeline integration test"
+    elseif !pipeline_integration_2024_available
+        @test_skip "2024 pisp-downloads material is absent; pipeline integration test requires the real AEMO workbooks/CSVs"
+    else
+        paths = PISP.default_data_paths(filepath=pipeline_integration_2024_edition.download_root)
+
+        tc, ts, tv = PISP.initialise_time_structures()
+        PISP.fill_problem_table_drange(tc, DateTime(2030, 1, 1, 0, 0, 0), DateTime(2030, 1, 1, 23, 0, 0); sce=[2])
+
+        static_artifacts = PISP.populate_time_static!(ts, tv, paths; refyear=4006, poe=10)
+        PISP.populate_time_varying!(tc, ts, tv, paths, static_artifacts; refyear=4006, poe=10, skip_traces=false)
+
+        @testset "static tables (ts)" begin
+            @test size(ts.bus) == (12, 7)
+            @test names(ts.bus) == ["id_bus", "name", "alias", "active", "latitude", "longitude", "id_area"]
+            @test collect(ts.bus[1, :]) == Any[1, "NQ", "Northern Queensland", true, -17.79385, 145.5635, 1]
+
+            @test size(ts.dem) == (12, 8)
+            @test names(ts.dem) == ["id_dem", "name", "load_", "id_bus", "active", "controllable", "voll", "contingency"]
+
+            @test size(ts.ess) == (73, 37)
+            @test names(ts.ess) == ["id_ess", "name", "alias", "tech", "type", "capacity", "investment",
+                                     "active", "id_bus", "ch_eff", "dch_eff", "eini", "emin", "emax", "pmin",
+                                     "pmax", "lmin", "lmax", "fullout", "partialout", "mttrfull", "mttrpart",
+                                     "inertia", "powerfactor", "ffr", "pfr", "res2", "res3", "fr_db", "fr_ad",
+                                     "fr_dt", "fr_frt", "fr_fr", "longitude", "latitude", "n", "contingency"]
+
+            @test size(ts.gen) == (124, 48)
+            @test names(ts.gen) == ["id_gen", "name", "alias", "fuel", "tech", "type", "capacity", "forate",
+                                     "fullout", "partialout", "derate", "mttrfull", "mttrpart", "id_bus", "pmin",
+                                     "pmax", "rup", "rdw", "investment", "active", "cvar", "cfuel", "cvom",
+                                     "cfom", "co2", "slope", "hrate", "pfrmax", "g", "inertia", "ffr", "pfr",
+                                     "res2", "res3", "powerfactor", "latitude", "longitude", "n", "contingency",
+                                     "down_time", "up_time", "last_state", "last_state_period",
+                                     "last_state_output", "start_up_cost", "shut_down_cost", "start_up_time",
+                                     "shut_down_time"]
+            @test collect(ts.gen[1, 1:8]) ==
+                  Any[1, "Bayswater", "BW01", "Coal", "Black Coal NSW", "Steam Sub Critical", 678.75, 0.6745236000000001]
+
+            @test size(ts.line) == (54, 22)
+            @test names(ts.line) == ["id_lin", "name", "alias", "tech", "capacity", "id_bus_from", "id_bus_to",
+                                      "investment", "active", "r", "x", "rvcap", "fwcap", "fullout", "mttrfull",
+                                      "voltage", "segments", "latitude", "longitude", "length", "n", "contingency"]
+
+            @test size(ts.der) == (72, 11)
+            @test names(ts.der) == ["id_der", "name", "tech", "id_dem", "active", "investment", "capacity",
+                                     "reduct", "pred_max", "cost_red", "n"]
+        end
+
+        @testset "time-varying tables (tv)" begin
+            @test size(tv.dem_load) == (288, 5)
+            @test collect(tv.dem_load[1, :]) == Any[1, 1, 2, DateTime(2030, 1, 1, 0, 0, 0), 749.427093165194]
+
+            @test size(tv.ess_emax) == (12, 5)
+            @test size(tv.ess_lmax) == (12, 5)
+            @test size(tv.ess_n) == (84, 5)
+
+            @test size(tv.ess_pmax) == (12, 5)
+            @test collect(tv.ess_pmax[1, :]) == Any[1, 62, 2, DateTime(2030, 1, 1, 0, 0, 0), 118.8294867]
+
+            @test size(tv.ess_inflow) == (24, 5)
+            @test collect(tv.ess_inflow[1, :]) == Any[1, 59, 2, DateTime(2030, 1, 1, 0, 0, 0), 4.9647956459628055]
+
+            @test size(tv.gen_n) == (201, 5)
+
+            @test size(tv.gen_pmax) == (795, 5)
+            @test collect(tv.gen_pmax[1, :]) == Any[1, 78, 1, DateTime(2044, 7, 1, 0, 0, 0), 106.0]
+
+            @test size(tv.gen_inflow) == (720, 5)
+            @test collect(tv.gen_inflow[1, :]) == Any[1, 23, 2, DateTime(2030, 1, 1, 0, 0, 0), 4.38160830479452]
+
+            @test size(tv.line_fwcap) == (20, 5)
+            @test collect(tv.line_fwcap[1, :]) == Any[1, 15, 1, DateTime(2024, 7, 1, 0, 0, 0), 150.0]
+
+            @test size(tv.line_rvcap) == (20, 5)
+
+            @test size(tv.der_pred) == (11448, 5)
+            @test collect(tv.der_pred[1, :]) == Any[1, 1, 1, DateTime(2023, 11, 1, 0, 0, 0), 0.0]
+        end
+    end
+end

--- a/test/test_source_specs.jl
+++ b/test/test_source_specs.jl
@@ -1,0 +1,93 @@
+# Characterization tests for the hardcoded workbook/worksheet/range and CSV-pattern
+# literals scattered across the parser code (workbook path, worksheet name, and cell
+# range or file-glob passed to each reader). These lock in the real column names,
+# dimensions, and spot-check values that any future refactor of those literals must
+# preserve, using the same "one higher" readers the parser code itself calls
+# (PISP.read_xlsx_with_header, CSV.read/CSV.File) rather than the raw
+# XLSX.readdata/XLSX.openxlsx primitive. Skipped gracefully (not failed) when the real
+# AEMO workbooks are absent, since CI has no access to them.
+
+using DataFrames
+using CSV
+
+source_specs_edition_2024 = only(filter(
+    p -> p.edition == "2024",
+    source_availability_profiles(normpath(joinpath(@__DIR__, ".."))),
+))
+source_specs_2024_available = inspect_edition(source_specs_edition_2024).state == :complete
+
+@testset "source specs: hardcoded 2024 workbook/CSV read contracts" begin
+    if !source_specs_2024_available
+        @test_skip "2024 pisp-downloads material is absent; source-spec characterization requires the real AEMO workbooks/CSVs"
+    else
+        paths = PISP.default_data_paths(filepath=source_specs_edition_2024.download_root)
+
+        @testset "existing_generators — 2024-isp-inputs-and-assumptions-workbook.xlsx / Existing Gen Data Summary / B11:K297" begin
+            df = PISP.read_xlsx_with_header(paths.ispdata24, "Existing Gen Data Summary", "B11:K297")
+            # The header row in this range is blank; read_xlsx_with_header's `string(missing)`
+            # conversion turns each blank cell into the literal string "missing" before the
+            # empty-header fallback runs, so makeunique numbers the duplicates instead of
+            # falling back to "Column_N". Production code (gen_pmax_solar/gen_pmax_wind)
+            # reads this table positionally, never by name, so this is real existing behaviour.
+            @test names(df) == ["missing", "missing_1", "missing_2", "missing_3", "missing_4",
+                                 "missing_5", "missing_6", "missing_7", "missing_8", "missing_9"]
+            @test size(df) == (286, 10)
+            @test collect(df[end, :]) ==
+                  Any["Wambo Wind Farm", "Wind", "QLD", "SQ", "Darling Downs", "Wind", 252, 252, 252, 252]
+        end
+
+        @testset "network_capability — 2024-isp-inputs-and-assumptions-workbook.xlsx / Network Capability / B6:H21" begin
+            df = PISP.read_xlsx_with_header(paths.ispdata24, "Network Capability", "B6:H21")
+            @test names(df) == ["Flow paths\n(Forward power flow direction)",
+                                 "Forward direction capability approximation (MW) - Notes 1,2&3",
+                                 "missing", "missing_1",
+                                 "Reverse direction capability approximation (MW) - Notes 1,2&3",
+                                 "missing_2", "missing_3"]
+            @test size(df) == (15, 7)
+            @test collect(df[end, :]) == Any["TAS – VIC (Note 12)", 594, 594, 594, 478, 478, 478]
+        end
+
+        @testset "legacy_min_up_time — 2019-input-and-assumptions-workbook-v1-3-dec-19.xlsx / Generation limits / O9:Q69" begin
+            df = PISP.read_xlsx_with_header(paths.ispdata19, "Generation limits", "O9:Q69")
+            @test names(df) == ["Generator Station", "Generating unit", "Min Up Time (hours)"]
+            @test size(df) == (60, 3)
+            @test collect(df[1, :]) == Any["Bayswater", "BW01", 8]
+            @test collect(df[end, :]) == Any["Tamar Valley Combined Cycle", "TVCC201", 6]
+        end
+
+        @testset "core_capacity_outlook — Core/2024 ISP - Step Change - Core.xlsx / Capacity / A3:AG5000" begin
+            file = joinpath(paths.outlookdata, "2024 ISP - Step Change - Core.xlsx")
+            df = PISP.read_xlsx_with_header(file, "Capacity", "A3:AG5000")
+            @test size(df) == (4997, 33)
+            @test names(df)[1:8] ==
+                  ["CDP", "Region", "Subregion", "Technology", "2023-24", "2024-25", "2025-26", "2026-27"]
+            # build_capacity_outlook_aux (src/scrappers/PISP-scrapper-build.jl) drops rows with
+            # no numeric value anywhere before combining scenarios; matched here for parity.
+            filtered = filter(row -> any(x -> x isa Number && !ismissing(x), row), df)
+            @test size(filtered) == (4290, 33)
+            @test collect(filtered[1, 1:8]) == Any["CDP1", "NSW", "NNSW", "Black coal", 0, 0, 0, 0]
+            @test collect(filtered[end, 1:8]) ==
+                  Any["Counterfactual", "TAS", "TAS", "DSP", 5.95, 8.19, 10.4, 12.81]
+        end
+
+        @testset "demand_trace — Traces/demand_CNSW_Step Change/CNSW_RefYear_2011_STEP_CHANGE_POE10_OPSO_MODELLING_PVLITE.csv" begin
+            file = joinpath(paths.profiledata, "demand_CNSW_Step Change",
+                             "CNSW_RefYear_2011_STEP_CHANGE_POE10_OPSO_MODELLING_PVLITE.csv")
+            df = CSV.File(file) |> DataFrame
+            @test size(df) == (11323, 51)
+            @test names(df)[1:8] == ["Year", "Month", "Day", "01", "02", "03", "04", "05"]
+            @test collect(df[1, 1:3]) == Real[2023, 7, 1]
+            @test collect(df[end, 1:3]) == Real[2054, 6, 30]
+        end
+
+        @testset "hydro_inflow_trace — 2024 ISP Model/2024 ISP Step Change/Traces/hydro/MonthlyNaturalInflow_Tarraleah_RefYear4006_StepChange.csv" begin
+            file = joinpath(paths.ispmodel, "2024 ISP Step Change", "Traces", "hydro",
+                             "MonthlyNaturalInflow_Tarraleah_RefYear4006_StepChange.csv")
+            df = CSV.read(file, DataFrame)
+            @test names(df) == ["Year", "Month", "Day", "Inflows"]
+            @test size(df) == (10592, 4)
+            @test collect(df[1, :]) == Real[2024, 7, 1, 32.1619225771939]
+            @test collect(df[end, :]) == Real[2053, 6, 30, 22.275636810599]
+        end
+    end
+end

--- a/test/test_source_specs.jl
+++ b/test/test_source_specs.jl
@@ -1,11 +1,11 @@
-# Characterization tests for the hardcoded workbook/worksheet/range and CSV-pattern
-# literals scattered across the parser code (workbook path, worksheet name, and cell
-# range or file-glob passed to each reader). These lock in the real column names,
-# dimensions, and spot-check values that any future refactor of those literals must
-# preserve, using the same "one higher" readers the parser code itself calls
-# (PISP.read_xlsx_with_header, CSV.read/CSV.File) rather than the raw
-# XLSX.readdata/XLSX.openxlsx primitive. Skipped gracefully (not failed) when the real
-# AEMO workbooks are absent, since CI has no access to them.
+# Characterisation tests for the hard-coded 2024 source specifications.
+#
+# Each test reads a workbook range or CSV file used by the parser and checks its
+# columns, dimensions, and representative values. Together, these checks define
+# the source-data contracts that parser refactors must preserve.
+#
+# The tests use the same readers as the parser and skip when the required local
+# AEMO data is unavailable.
 
 using DataFrames
 using CSV
@@ -24,11 +24,9 @@ source_specs_2024_available = inspect_edition(source_specs_edition_2024).state =
 
         @testset "existing_generators — 2024-isp-inputs-and-assumptions-workbook.xlsx / Existing Gen Data Summary / B11:K297" begin
             df = PISP.read_xlsx_with_header(paths.ispdata24, "Existing Gen Data Summary", "B11:K297")
-            # The header row in this range is blank; read_xlsx_with_header's `string(missing)`
-            # conversion turns each blank cell into the literal string "missing" before the
-            # empty-header fallback runs, so makeunique numbers the duplicates instead of
-            # falling back to "Column_N". Production code (gen_pmax_solar/gen_pmax_wind)
-            # reads this table positionally, never by name, so this is real existing behaviour.
+            # This range has a blank header row. `read_xlsx_with_header` converts each blank
+            # cell to `"missing"` and numbers the duplicate names. The parser reads this
+            # table by column position rather than by name.
             @test names(df) == ["missing", "missing_1", "missing_2", "missing_3", "missing_4",
                                  "missing_5", "missing_6", "missing_7", "missing_8", "missing_9"]
             @test size(df) == (286, 10)
@@ -61,8 +59,8 @@ source_specs_2024_available = inspect_edition(source_specs_edition_2024).state =
             @test size(df) == (4997, 33)
             @test names(df)[1:8] ==
                   ["CDP", "Region", "Subregion", "Technology", "2023-24", "2024-25", "2025-26", "2026-27"]
-            # build_capacity_outlook_aux (src/scrappers/PISP-scrapper-build.jl) drops rows with
-            # no numeric value anywhere before combining scenarios; matched here for parity.
+            # Match `build_capacity_outlook_aux`, which removes rows without any numeric
+            # values before combining the scenarios.
             filtered = filter(row -> any(x -> x isa Number && !ismissing(x), row), df)
             @test size(filtered) == (4290, 33)
             @test collect(filtered[1, 1:8]) == Any["CDP1", "NSW", "NNSW", "Black coal", 0, 0, 0, 0]


### PR DESCRIPTION
This add simple test set that increase coverage to 74.14%.

```text
Per-file coverage
=================
src/PISP.jl                                                        0 / 0      0.0%
src/PISPdatamodel.jl                                               0 / 0      0.0%
src/PISPparameters.jl                                              0 / 0      0.0%
src/PISPparsers.jl                                                 0 / 0      0.0%
src/PISPscrappers.jl                                               0 / 0      0.0%
src/PISPstructures.jl                                              0 / 0      0.0%
src/PISPutils.jl                                                   0 / 0      0.0%
src/datamodel/PISPdata-config.jl                                   0 / 0      0.0%
src/datamodel/PISPdata-infrastructure.jl                           0 / 0      0.0%
src/datamodel/PISPdata-schedule.jl                                 0 / 0      0.0%
src/main/pipeline-add-buildouts.jl                                 0 / 0      0.0%
src/main/pipeline-data-full.jl                                     0 / 0      0.0%
src/parameters/buildout2024ISP.jl                                  0 / 0      0.0%
src/parameters/ess2024ISP.jl                                       0 / 0      0.0%
src/parameters/general2024ISP.jl                                   0 / 0      0.0%
src/parameters/gens2024ISP.jl                                      8 / 8    100.0%
src/parameters/hydro2024ISP.jl                                     0 / 0      0.0%
src/parameters/retirements2024ISP.jl                               0 / 0      0.0%
src/parsers/PISP-2024buildout.jl                               114 / 116    98.28%
src/parsers/PISP-2024core.jl                                     29 / 75    38.67%
src/parsers/PISP-2024ev.jl                                         0 / 0      0.0%
src/parsers/PISP-2024parser.jl                               1240 / 1258    98.57%
src/scrappers/PISP-scrapper-2024files.jl                          0 / 67      0.0%
src/scrappers/PISP-scrapper-2024reports.jl                         4 / 4    100.0%
src/scrappers/PISP-scrapper-2024traces.jl                         0 / 84      0.0%
src/scrappers/PISP-scrapper-2026files.jl                         19 / 22    86.36%
src/scrappers/PISP-scrapper-2026reports.jl                         4 / 4    100.0%
src/scrappers/PISP-scrapper-build.jl                             0 / 211      0.0%
src/scrappers/PISP-scrapper-report-core.jl                       37 / 44    84.09%
src/scrappers/PISP-scrapper-utils.jl                             26 / 79    32.91%
src/structures/PISPstructures-df.jl                              25 / 25    100.0%
src/utils/data_processing/PISPutils-2024ISP.jl                   37 / 41    90.24%
src/utils/data_processing/filterSortTimeseriesData.jl             0 / 49      0.0%
src/utils/dataframes/PISPutils-dataframes.jl                     31 / 44    70.45%
src/utils/dataframes/PISPutils-df-evs-2024.jl                  241 / 257    93.77%
src/utils/dataframes/PISPutils-df-hydro.jl                       53 / 55    96.36%
src/utils/general/PISPutils-general.jl                           16 / 82    19.51%
src/utils/mappers/PISPutils-mappers.jl                             0 / 0      0.0%
src/utils/writing/PISPutils-writing.jl                            0 / 16      0.0%

Overall coverage
================
Covered lines: 1884 / 2541
Coverage: 74.14%
```