### PR TITLE
Remove external EDA-producer execution from docs tooling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,10 @@ Its committed source override resolves PISP from the same checkout:
 PISP = {path = ".."}
 ```
 
+These are the local-maintainer environment defaults.
+The documentation scripts use the project selected when Julia starts and do not activate `docs/Project.toml` themselves.
+A separate environment with the required documentation dependencies can therefore be selected with `--project=<environment>`; `build_all.jl` and `render_changed.jl` preserve that active project when they start another documentation stage.
+
 The repository does not commit `Manifest.toml` files.
 Instantiate each environment from its `Project.toml`, and change dependency constraints only when dependencies are intentionally updated.
 Package and documentation-infrastructure tests use fixture or source-code checks unless a test explicitly declares an external-data prerequisite.
@@ -46,8 +50,7 @@ julia --project=docs docs/render_changed.jl
 ```
 
 `render_changed.jl` resolves the changed `docs/literate/**/*.jl` files (staged, unstaged, or untracked, versus `HEAD`) to their registry page IDs and re-renders just those in place through `PISP_LITERATE_PAGES`.
-It reports when a shared file changed (`eda_support.jl`, an EDA producer, or `page-registry.toml`), since those can affect many pages.
-Set `PISP_RUN_PRODUCERS=false` to reuse existing EDA evidence instead of re-running the producers.
+It reports changed documentation `.jl` files that are not registered page sources, such as `eda_support.jl` or `page_registry.jl`, since those can affect many pages.
 Run the full `docs/render_literate.jl` before committing regenerated Markdown; the changed-only path skips the whole-set completeness and atomic-replacement checks.
 
 ## Prepare local data for complete regeneration
@@ -166,7 +169,6 @@ The registry validates page metadata, source and output paths, navigation positi
 | `nav_order` | Position within a track and kind. |
 | `snapshot` | Whether the page describes a dated source or generated-data state. |
 | `data_requirements` | Typed local files or directories required before page execution. |
-| `producer` and `evidence_dir` | Optional external evidence producer and its directory. |
 | `related_reference_pages` | Static or generated pages defining the relevant package contract. |
 
 Use relative paths in registry metadata; paths that escape their declared root are rejected.
@@ -233,7 +235,7 @@ generated Markdown and local-observation tables. An absent root is not skipped
 by selected-page rendering. The optional skip-versus-fail behavior belongs only
 to the package-root fixture checks in `test/runtests.jl`.
 
-Before any producer or Literate page runs, the renderer resolves each selected requirement through the relevant edition profile and checks its type.
+Before any Literate page runs, the renderer resolves each selected requirement through the relevant edition profile and checks its type.
 The render plan prints selected page IDs, track and edition scope, resolved profiles, and resolved requirements.
 
 ## Validation commands
@@ -317,7 +319,7 @@ Use two complementary structures for executable documentation:
 6. Update related reference pages whenever a source, output, mapping, or support boundary changes.
 
 Executable validation and analysis pages should keep reader-facing evidence and interpretation with the code that computes them.
-Use `producer` and `evidence_dir` only when a separate producer is necessary; every registered path must be valid, and `evidence_dir` requires a `producer`.
+Keep executable page work in the registered source under `docs/literate/` or in a shared helper under `docs/`; do not route a page through a repository-external script.
 
 ## Implementation locations
 

--- a/docs/build_all.jl
+++ b/docs/build_all.jl
@@ -1,11 +1,19 @@
 # Complete local documentation build:
-# 1. regenerate registered EDA evidence and execute every active Literate page;
+# 1. execute every active Literate page and install its generated output;
 # 2. build the Documenter site.
 
 const DOCS_DIR = @__DIR__
 const REPO_ROOT = normpath(joinpath(DOCS_DIR, ".."))
-render_command = `$(Base.julia_cmd()) --project=$(DOCS_DIR) $(joinpath(DOCS_DIR, "render_literate.jl"))`
-make_command = `$(Base.julia_cmd()) --project=$(DOCS_DIR) $(joinpath(DOCS_DIR, "make.jl"))`
+
+function active_project_directory()
+    project = Base.active_project()
+    project === nothing && error("build_all.jl requires an active Julia project")
+    return dirname(project)
+end
+
+const PROJECT_DIR = active_project_directory()
+render_command = `$(Base.julia_cmd()) --project=$(PROJECT_DIR) $(joinpath(DOCS_DIR, "render_literate.jl"))`
+make_command = `$(Base.julia_cmd()) --project=$(PROJECT_DIR) $(joinpath(DOCS_DIR, "make.jl"))`
 
 function run_stage(label, command)
     println("\n=== $label ===")
@@ -13,13 +21,13 @@ function run_stage(label, command)
         run(Cmd(command; dir = REPO_ROOT))
     catch
         println(stderr, "\nERROR: Documentation build stopped during: $label")
-        label == "EDA and Literate regeneration" &&
+        label == "Literate regeneration" &&
             println(stderr, "Documenter was not run.")
         rethrow()
     end
 end
 
-run_stage("EDA and Literate regeneration", render_command)
+run_stage("Literate regeneration", render_command)
 run_stage("Documenter site build", make_command)
 
 println("\nDocumentation build completed: $(joinpath(DOCS_DIR, "build", "index.html"))")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,7 +30,7 @@ registry_pages = try
     load_page_registry(REGISTRY_PATH; require_published_outputs = true)
 catch
     println(stderr, "\nERROR: Documenter cannot start because one or more generated pages are missing or invalid.")
-    println(stderr, "Run: julia --project=docs docs/render_literate.jl")
+    println(stderr, "Run docs/render_literate.jl with the same active Julia project.")
     rethrow()
 end
 

--- a/docs/page_registry.jl
+++ b/docs/page_registry.jl
@@ -17,6 +17,22 @@ const VALID_TRACKS = Set(["shared", "isp2024", "isp2026", "comparison"])
 const VALID_EDITIONS = Set(["2024", "2026"])
 const VALID_REQUIREMENT_ROOTS = Set(["repo", "report", "download", "output"])
 const VALID_REQUIREMENT_TYPES = Set(["file", "directory", "path"])
+const VALID_PAGE_FIELDS = Set([
+    "id",
+    "title",
+    "kind",
+    "track",
+    "editions",
+    "data_layer",
+    "source",
+    "output",
+    "status",
+    "nav_order",
+    "snapshot",
+    "data_requirements",
+    "related_reference_pages",
+    "notes",
+])
 
 struct DataRequirement
     root::String
@@ -37,8 +53,6 @@ Base.@kwdef struct PageSpec
     status::String
     nav_order::Int
     snapshot::Bool
-    evidence_dir::Union{Nothing, String} = nothing
-    producer::Union{Nothing, String} = nothing
     data_requirements::Vector{DataRequirement} = DataRequirement[]
     related_reference_pages::Vector{String} = String[]
     notes::Union{Nothing, String} = nothing
@@ -78,6 +92,13 @@ function relative_path(value, field, page_id)
         error("page \"$page_id\" field \"$field\" escapes its root: $value")
     normalized == "." && error("page \"$page_id\" field \"$field\" cannot be current directory")
     return normalized
+end
+
+function validate_page_fields(entry, page_number)
+    unsupported = sort!(filter(key -> !(key in VALID_PAGE_FIELDS), String.(collect(keys(entry)))))
+    isempty(unsupported) || error(
+        "page $page_number has unsupported field(s): $(join(unsupported, ", "))",
+    )
 end
 
 function validate_track_editions(track, editions, page_id)
@@ -151,6 +172,8 @@ function parse_data_requirements(entry, page_id, page_number, page_editions)
 end
 
 function parse_page(entry, page_number)
+    validate_page_fields(entry, page_number)
+
     id = required_string(entry, "id", page_number)
     title = required_string(entry, "title", page_number)
     kind = required_string(entry, "kind", page_number)
@@ -176,14 +199,6 @@ function parse_page(entry, page_number)
     snapshot = get(entry, "snapshot", nothing)
     snapshot isa Bool || error("page \"$id\" requires boolean field \"snapshot\"")
 
-    evidence_dir = optional_string(entry, "evidence_dir", page_number)
-    evidence_dir === nothing || (evidence_dir = relative_path(evidence_dir, "evidence_dir", id))
-
-    producer = optional_string(entry, "producer", page_number)
-    producer === nothing || (producer = relative_path(producer, "producer", id))
-    evidence_dir !== nothing && producer === nothing &&
-        error("page \"$id\" requires a producer when evidence_dir is set")
-
     related_reference_pages = [
         relative_path(path, "related_reference_pages", id)
         for path in string_vector(entry, "related_reference_pages", page_number)
@@ -201,8 +216,6 @@ function parse_page(entry, page_number)
         status = status,
         nav_order = Int(nav_order),
         snapshot = snapshot,
-        evidence_dir = evidence_dir,
-        producer = producer,
         data_requirements = parse_data_requirements(entry, id, page_number, editions),
         related_reference_pages = related_reference_pages,
         notes = optional_string(entry, "notes", page_number),
@@ -238,18 +251,12 @@ function validate_files(
     check_generated_outputs,
 )
     docs_dir = dirname(registry_path)
-    repo_root = normpath(joinpath(docs_dir, ".."))
     src_root = joinpath(docs_dir, "src")
     registered_outputs = Set(page.output for page in pages)
 
     for page in pages
         source_path = joinpath(docs_dir, page.source)
         isfile(source_path) || error("page \"$(page.id)\" source does not exist: $source_path")
-
-        if page.producer !== nothing
-            producer_path = joinpath(repo_root, page.producer)
-            isfile(producer_path) || error("page \"$(page.id)\" producer does not exist: $producer_path")
-        end
 
         for reference_page in page.related_reference_pages
             reference_path = joinpath(src_root, reference_page)

--- a/docs/render_changed.jl
+++ b/docs/render_changed.jl
@@ -6,14 +6,13 @@
 #
 # Usage:
 #   julia --project=docs docs/render_changed.jl
-#   PISP_RUN_PRODUCERS=false julia --project=docs docs/render_changed.jl   # reuse existing EDA evidence
 #
 # SCOPE / CAVEAT: this tracks only changed docs/literate/**/*.jl page sources.
 # It does NOT detect changes to shared helpers (eda_support.jl, page_registry.jl),
-# EDA producer scripts, package src/, or local data -- any of which can change
-# many rendered pages. It also skips the full-set completeness/atomic-swap
-# validation that render_literate.jl performs for the whole published set.
-# Always run a full `julia --project=docs docs/render_literate.jl` before you
+# package src/, or local data -- any of which can change many rendered pages.
+# It also skips the full-set completeness/atomic-swap validation that
+# render_literate.jl performs for the whole published set.
+# Always run docs/render_literate.jl with the same active project before you
 # commit regenerated Markdown.
 
 include(joinpath(@__DIR__, "page_registry.jl"))
@@ -26,6 +25,12 @@ const RENDER_SCRIPT = joinpath(DOCS_DIR, "render_literate.jl")
 function git_lines(args)
     out = read(Cmd(`git $(args)`; dir = REPO_ROOT), String)
     return filter(!isempty, strip.(split(out, '\n')))
+end
+
+function active_project_directory()
+    project = Base.active_project()
+    project === nothing && error("render_changed.jl requires an active Julia project")
+    return dirname(project)
 end
 
 function changed_docs_jl()
@@ -60,7 +65,7 @@ function main()
 
     if !isempty(changed_other)
         println("NOTE: changed docs .jl files that are not registry page sources")
-        println("      (shared helper / producer / registry) -- these can affect many")
+        println("      (shared helper / registry) -- these can affect many")
         println("      pages, so a full render is recommended:")
         for path in changed_other
             println("  - $(path)")
@@ -70,13 +75,14 @@ function main()
 
     if isempty(changed_pages)
         println("No changed renderable Literate page sources vs HEAD; nothing to render.")
-        println("(Run `julia --project=docs docs/render_literate.jl` for a full render.)")
+        println("(Run docs/render_literate.jl with the same active project for a full render.)")
         return
     end
 
     println("Changed pages to re-render: ", join(changed_pages, ", "))
     ENV["PISP_LITERATE_PAGES"] = join(changed_pages, ",")
-    run(Cmd(`$(Base.julia_cmd()) --project=$(DOCS_DIR) $(RENDER_SCRIPT)`; dir = REPO_ROOT))
+    project_directory = active_project_directory()
+    run(Cmd(`$(Base.julia_cmd()) --project=$(project_directory) $(RENDER_SCRIPT)`; dir = REPO_ROOT))
     println("\nIncremental render complete. Run a full render before committing regenerated Markdown.")
 end
 

--- a/docs/render_literate.jl
+++ b/docs/render_literate.jl
@@ -1,7 +1,7 @@
 # Regenerate committed Markdown for every active registry-managed Literate page.
 #
 # Run this script before the Documenter build whenever package code, local data,
-# EDA evidence, or a Literate source changes.
+# a documentation helper, or a Literate source changes.
 
 using Literate
 
@@ -14,13 +14,6 @@ const REPO_ROOT = normpath(joinpath(DOCS_DIR, ".."))
 const REGISTRY_PATH = joinpath(DOCS_DIR, "page-registry.toml")
 const TRACK_ORDER = Dict("shared" => 1, "isp2024" => 2, "isp2026" => 3, "comparison" => 4)
 const KIND_ORDER = Dict("reference" => 1, "tutorial" => 2, "validation" => 3, "analysis" => 4)
-
-function env_flag(name, default)
-    value = lowercase(strip(get(ENV, name, default ? "true" : "false")))
-    value in ("1", "true", "yes", "on") && return true
-    value in ("0", "false", "no", "off") && return false
-    error("$name must be one of true/false, yes/no, on/off, or 1/0")
-end
 
 function select_pages(registry_pages)
     explicit_ids = strip(get(ENV, "PISP_LITERATE_PAGES", ""))
@@ -141,50 +134,6 @@ function print_render_plan(pages, profiles)
     requirements_found || println("  - none")
 end
 
-function selected_producers(pages)
-    producers = Pair{String, Vector{String}}[]
-    index_by_path = Dict{String, Int}()
-
-    for page in pages
-        page.producer === nothing && continue
-        if haskey(index_by_path, page.producer)
-            push!(producers[index_by_path[page.producer]].second, page.id)
-        else
-            push!(producers, page.producer => [page.id])
-            index_by_path[page.producer] = length(producers)
-        end
-    end
-
-    return producers
-end
-
-function run_producer(relative_path, page_ids)
-    producer_path = joinpath(REPO_ROOT, relative_path)
-    command = `$(Base.julia_cmd()) --project=$(REPO_ROOT) $(producer_path)`
-    println("\n=== EDA producer: $relative_path ===")
-    println("Pages: $(join(page_ids, ", "))")
-
-    try
-        run(Cmd(command; dir = REPO_ROOT))
-    catch
-        println(stderr, "\nERROR: EDA producer failed: $relative_path")
-        println(stderr, "Affected pages: $(join(page_ids, ", "))")
-        println(stderr, "No Literate page using this producer was rendered.")
-        rethrow()
-    end
-end
-
-function run_selected_producers(pages)
-    env_flag("PISP_RUN_PRODUCERS", true) || begin
-        println("Skipping registered EDA producers because PISP_RUN_PRODUCERS=false.")
-        return
-    end
-
-    for (producer, page_ids) in selected_producers(pages)
-        run_producer(producer, page_ids)
-    end
-end
-
 function collapse_julia_source(markdown)
     lines = split(markdown, '\n'; keepempty = true)
     output = String[]
@@ -239,17 +188,6 @@ function set_edit_url(markdown, source_path, final_output_path)
     return join(lines, '\n')
 end
 
-function validate_render_preconditions(page)
-    if page.evidence_dir !== nothing
-        evidence_path = joinpath(REPO_ROOT, page.evidence_dir)
-        isdir(evidence_path) || error(
-            "page \"$(page.id)\" expects EDA evidence at \"$evidence_path\"; " *
-            "run julia --project=. $(page.producer) from the repository root first",
-        )
-    end
-
-end
-
 function validate_selected_requirements(pages, profiles)
     for page in pages
         PISPDocsPageRegistry.validate_data_requirements(
@@ -282,8 +220,6 @@ function with_page_environment(callback, output_dir)
 end
 
 function render_page(page; src_dir = SRC_DIR)
-    validate_render_preconditions(page)
-
     source_path = joinpath(DOCS_DIR, page.source)
     output_path = joinpath(src_dir, page.output)
     output_dir = dirname(output_path)
@@ -438,8 +374,6 @@ function main()
     selected_ids = Set(page.id for page in selected_pages)
     rendering_all_published = selected_ids == published_ids
     try
-        run_selected_producers(selected_pages)
-
         if rendering_all_published
             render_all_published(selected_pages)
             println("Validated all published generated outputs against the page registry.")

--- a/docs/test/runtests.jl
+++ b/docs/test/runtests.jl
@@ -314,6 +314,7 @@ function fixture_page(
     nav_order=10,
     snapshot=false,
     data_requirements=nothing,
+    extra_fields="",
 )
     edition_values = join(repr.(editions), ", ")
     requirement_line = data_requirements === nothing ? "" : "\ndata_requirements = $(data_requirements)"
@@ -329,7 +330,7 @@ function fixture_page(
     output = "$(output)"
     status = "$(status)"
     nav_order = $(nav_order)
-    snapshot = $(snapshot)$(requirement_line)
+    snapshot = $(snapshot)$(requirement_line)$(extra_fields)
     """
     return (; id, source, output, status, block)
 end
@@ -491,6 +492,16 @@ end
             with_registry_fixture([invalid_page]) do registry_path, _
                 @test_throws ErrorException load_page_registry(registry_path)
             end
+        end
+    end
+
+    @testset "unsupported page fields are rejected" begin
+        page = fixture_page(
+            id="unsupported-field",
+            extra_fields="\nexternal_step = \"script.jl\"",
+        )
+        with_registry_fixture([page]) do registry_path, _
+            @test_throws ErrorException load_page_registry(registry_path)
         end
     end
 


### PR DESCRIPTION
The Literate renderer and page registry no longer select, validate, or launch repository-external EDA producer scripts, and no longer require an evidence directory precondition before rendering.