### PR TITLE
Refactor source specs

### DIFF
--- a/docs/literate/isp2024/validation/temperature_data_coverage.jl
+++ b/docs/literate/isp2024/validation/temperature_data_coverage.jl
@@ -6,6 +6,7 @@
 # This distinction matters for weather-aware studies: regional reference temperatures and temperature-dependent network limits are model assumptions, while an hourly weather series is an external input that needs its own source and mapping.
 
 using DataFrames
+using PISP
 using XLSX
 
 repo_root = normpath(get(ENV, "PISP_DOCS_REPO_ROOT", joinpath(@__DIR__, "..", "..", "..", "..")))
@@ -96,12 +97,7 @@ markdown_table(murraylink_temperature_capability)
 # The later regional-temperature and Murraylink lookup tables are outside the range currently read by `line_table`.
 # The package source also contains no field or parser identifier named `temperature`.
 
-parser_path = joinpath(repo_root, "src", "parsers", "PISP-2024parser.jl")
-parser_text = read(parser_path, String)
-network_capability_ranges = [
-    match_result.captures[1]
-    for match_result in eachmatch(r"\"Network Capability\",\s*\"([^\"]+)\"", parser_text)
-]
+network_capability_ranges = [PISP.source_spec(:network_capability, 2024).cell_range]
 
 source_files = String[]
 for (directory, _, files) in walkdir(joinpath(repo_root, "src"))

--- a/docs/src/generated/comparison/analyses/raw-source-comparison.md
+++ b/docs/src/generated/comparison/analyses/raw-source-comparison.md
@@ -341,3 +341,4 @@ markdown_table(source_family_changes; alignment = [:l, :l, :l, :l, :l])
 Detailed evidence is organised by subject under [AEMO ISP source material](../../shared/source-material/coverage-and-ownership.md).
 The [model archive comparison](model-archive-comparison.md) remains the authority for archive packaging, and the existing PISP dataset pages remain the authority for generated output schemas.
 No table on this page claims that ISP 2026 has an integrated PISP preprocessing or dataset workflow.
+

--- a/docs/src/generated/isp2024/validation/temperature-data-coverage.md
+++ b/docs/src/generated/isp2024/validation/temperature-data-coverage.md
@@ -15,6 +15,7 @@ This distinction matters for weather-aware studies: regional reference temperatu
 
 ````julia
 using DataFrames
+using PISP
 using XLSX
 
 repo_root = normpath(get(ENV, "PISP_DOCS_REPO_ROOT", joinpath(@__DIR__, "..", "..", "..", "..")))
@@ -179,12 +180,7 @@ The package source also contains no field or parser identifier named `temperatur
 ```
 
 ````julia
-parser_path = joinpath(repo_root, "src", "parsers", "PISP-2024parser.jl")
-parser_text = read(parser_path, String)
-network_capability_ranges = [
-    match_result.captures[1]
-    for match_result in eachmatch(r"\"Network Capability\",\s*\"([^\"]+)\"", parser_text)
-]
+network_capability_ranges = [PISP.source_spec(:network_capability, 2024).cell_range]
 
 source_files = String[]
 for (directory, _, files) in walkdir(joinpath(repo_root, "src"))

--- a/docs/src/generated/shared/source-material/coverage-and-ownership.md
+++ b/docs/src/generated/shared/source-material/coverage-and-ownership.md
@@ -231,3 +231,4 @@ markdown_table(mapping_owners)
 ISP 2024 rows describe implementation evidence in the current package.
 ISP 2026 has no integrated PISP preprocessing or dataset workflow, so its pages report observed source structure and mark semantic correspondences for review instead of presenting them as implemented mappings.
 The machine-readable authority is `docs/source-material-coverage.toml` in the repository.
+

--- a/docs/src/generated/shared/source-material/demand-and-distributed-resources.md
+++ b/docs/src/generated/shared/source-material/demand-and-distributed-resources.md
@@ -194,3 +194,4 @@ markdown_table(distribution_network_2026)
 
 The ISP 2024 dataset builder derives demand-by-bus relationships from its generated demand table and separately applies the EV allocation workflow.
 The additional ISP 2026 worksheets are observed source material; they are not evidence of an integrated 2026 PISP demand or distributed-resource builder.
+

--- a/docs/src/generated/shared/source-material/demand-side-participation.md
+++ b/docs/src/generated/shared/source-material/demand-side-participation.md
@@ -176,3 +176,4 @@ markdown_table(scenario_mapping)
 
 A future ISP 2026 implementation needs a reviewed mapping for the new row schema and scenario set.
 The visible similarity of price-band labels does not establish complete semantic equivalence.
+

--- a/docs/src/generated/shared/source-material/electric-vehicles.md
+++ b/docs/src/generated/shared/source-material/electric-vehicles.md
@@ -273,3 +273,4 @@ markdown_table(ev_output_fields)
 
 The 2025 IASR workbook is documented here as observed source evidence.
 PISP does not currently claim an integrated ISP 2026 EV preprocessing or dataset workflow.
+

--- a/docs/src/generated/shared/source-material/existing-generation-and-storage.md
+++ b/docs/src/generated/shared/source-material/existing-generation-and-storage.md
@@ -216,3 +216,4 @@ markdown_table(package_collections)
 
 PISP currently implements the ISP 2024 transformation path.
 The ISP 2026 tables above are observed source evidence and do not imply an integrated 2026 PISP dataset builder.
+

--- a/docs/src/generated/shared/source-material/generation-and-storage-outlook.md
+++ b/docs/src/generated/shared/source-material/generation-and-storage-outlook.md
@@ -235,3 +235,4 @@ markdown_table(storage_capacity_2026)
 The current scraper reads the 2024 capacity, storage, and REZ worksheets and writes condensed `Auxiliary/` workbooks used by the ISP 2024 parser.
 Those intermediates are PISP-generated material, not AEMO source publications.
 No corresponding integrated ISP 2026 scraper-to-dataset workflow is claimed here.
+

--- a/docs/src/generated/shared/source-material/generator-operation.md
+++ b/docs/src/generated/shared/source-material/generator-operation.md
@@ -326,3 +326,5 @@ markdown_table(ramp_2026)
 | BARCALDN | Barcaldine Power Station | OCGT (small GT) | 3.3 | 3.3 |
 | BIPS1\_01 | Barker Inlet Power Station | Reciprocating engine | 5.0 | 4.25 |
 | BIPS1\_02 | Barker Inlet Power Station | Reciprocating engine | 5.0 | 4.25 |
+
+

--- a/docs/src/generated/shared/source-material/generator-reliability-and-retirement.md
+++ b/docs/src/generated/shared/source-material/generator-reliability-and-retirement.md
@@ -235,3 +235,5 @@ markdown_table(retirement_conventions)
 | 1 | Progressive Change | 50 | 1 |
 | 2 | Step Change | 50 | 1 |
 | 3 | Green Energy Exports | 50 | 1 |
+
+

--- a/docs/src/generated/shared/source-material/hydro-inflows-and-energy-constraints.md
+++ b/docs/src/generated/shared/source-material/hydro-inflows-and-energy-constraints.md
@@ -247,3 +247,4 @@ markdown_table(hydro_conventions)
 
 This page covers bounded hydro inputs required by the parser, not the bulk renewable or demand trace payloads.
 ISP 2026 workbook inflows are observed source evidence and are not presented as an integrated PISP 2026 hydro workflow.
+

--- a/docs/src/generated/shared/source-material/network-and-transmission.md
+++ b/docs/src/generated/shared/source-material/network-and-transmission.md
@@ -275,3 +275,4 @@ markdown_table(network_geography)
 
 PISP currently implements these selections for ISP 2024.
 The ISP 2026 evidence above identifies source changes that require a reviewed parser design before they can define a 2026 dataset.
+

--- a/docs/src/generated/shared/source-material/renewable-energy-zones.md
+++ b/docs/src/generated/shared/source-material/renewable-energy-zones.md
@@ -165,3 +165,4 @@ markdown_table(rez_conventions)
 
 The cost-development-path choices are package conventions, not values read from the REZ worksheet.
 ISP 2026 zone names and fields require semantic review before reuse in a future transformation.
+

--- a/docs/src/generated/shared/source-material/scenarios-and-sensitivities.md
+++ b/docs/src/generated/shared/source-material/scenarios-and-sensitivities.md
@@ -178,3 +178,4 @@ markdown_table(outlook_cases)
 The 2024 set contains three core workbooks and nine sensitivities.
 The 2026 set contains three core workbooks and six sensitivities.
 Additions, removals, and renamed cases should be interpreted from their published assumptions, not inferred mechanically from similar filenames.
+

--- a/scripts/audit_source_spec_equivalence.jl
+++ b/scripts/audit_source_spec_equivalence.jl
@@ -1,0 +1,230 @@
+#!/usr/bin/env julia
+
+using CSV
+using DataFrames
+using PISP
+using SHA
+using TOML
+using XLSX
+
+const ISP24 = "2024-isp-inputs-and-assumptions-workbook.xlsx"
+const ISP19 = "2019-input-and-assumptions-workbook-v1-3-dec-19.xlsx"
+const SCENARIOS = ["Green Energy Exports", "Progressive Change", "Step Change"]
+
+struct Case
+    id::String
+    source_id::Symbol
+    workbook::String
+    worksheet::String
+    range::Union{Nothing,String}
+    replacements::NamedTuple
+end
+
+Case(id, source_id, workbook, worksheet, range; replacements=(;)) =
+    Case(id, source_id, workbook, worksheet, range, replacements)
+
+const CORE_CASES = [
+    ("network_capability", "Network Capability", "B6:H21"),
+    ("transmission_reliability", "Transmission Reliability", "B7:G11"),
+    ("flow_path_augmentation_options", "Flow Path Augmentation options", "B11:N94"),
+    ("generator_summary_mapping_names", "Summary Mapping", "B6:B680"),
+    ("generator_summary_mapping_mlf", "Summary Mapping", "AA6:AA680"),
+    ("existing_generator_maximum_capacity", "Maximum capacity", "B8:D260"),
+    ("committed_generator_maximum_capacity", "Maximum capacity", "F8:I35"),
+    ("anticipated_generator_maximum_capacity", "Maximum capacity", "K8:N24"),
+    ("generator_summary_mapping", "Summary Mapping", "B4:I680"),
+    ("coal_minimum_stable_generation", "Generation limits", "B8:D52"),
+    ("gpg_minimum_stable_generation", "GPG Min Stable Level", "B9:E34"),
+    ("generator_minimum_up_down_times", "Min Up&Down Times", "B8:E25"),
+    ("generator_maximum_ramp_rates", "Max Ramp Rates", "B8:F72"),
+    ("generator_retirements", "Retirement", "B9:D460"),
+    ("existing_generator_reliability", "Generator Reliability Settings", "B20:G28"),
+    ("new_generator_reliability", "Generator Reliability Settings", "I20:N40"),
+    ("existing_generator_summary", "Existing Gen Data Summary", "B10:U319"),
+    ("additional_generator_summary", "Existing Gen Data Summary", "B382:U397"),
+    ("generator_emissions_intensity", "Emissions intensity", "B7:D73"),
+    ("bess_storage_properties", "Storage properties", "B4:H13"),
+    ("pumped_storage_properties", "Storage properties", "B22:K26"),
+    ("bess_maximum_capacity", "Maximum capacity", "P8:U62"),
+    ("bess_summary_mapping", "Summary Mapping", "B314:AB370"),
+    ("existing_generators", "Existing Gen Data Summary", "B11:K297"),
+    ("renewable_energy_zones", "Renewable Energy Zones", "B7:G50"),
+]
+
+const DSP_CASES = [
+    ("progressive_change", "QLD", "SUMMER", "B128:AG133"), ("progressive_change", "QLD", "WINTER", "B137:AG142"),
+    ("progressive_change", "NSW", "SUMMER", "B108:AG113"), ("progressive_change", "NSW", "WINTER", "B118:AG123"),
+    ("progressive_change", "SA", "SUMMER", "B147:AG152"), ("progressive_change", "SA", "WINTER", "B156:AG161"),
+    ("progressive_change", "TAS", "SUMMER", "B166:AG171"), ("progressive_change", "TAS", "WINTER", "B175:AG180"),
+    ("progressive_change", "VIC", "SUMMER", "B185:AG190"), ("progressive_change", "VIC", "WINTER", "B194:AG199"),
+    ("step_change", "QLD", "SUMMER", "B226:AG231"), ("step_change", "QLD", "WINTER", "B235:AG240"),
+    ("step_change", "NSW", "SUMMER", "B206:AG211"), ("step_change", "NSW", "WINTER", "B216:AG221"),
+    ("step_change", "SA", "SUMMER", "B245:AG250"), ("step_change", "SA", "WINTER", "B254:AG259"),
+    ("step_change", "TAS", "SUMMER", "B264:AG269"), ("step_change", "TAS", "WINTER", "B273:AG278"),
+    ("step_change", "VIC", "SUMMER", "B283:AG288"), ("step_change", "VIC", "WINTER", "B292:AG297"),
+    ("green_energy_exports", "QLD", "SUMMER", "B30:AG35"), ("green_energy_exports", "QLD", "WINTER", "B39:AG44"),
+    ("green_energy_exports", "NSW", "SUMMER", "B10:AG15"), ("green_energy_exports", "NSW", "WINTER", "B20:AG25"),
+    ("green_energy_exports", "SA", "SUMMER", "B49:AG54"), ("green_energy_exports", "SA", "WINTER", "B58:AG63"),
+    ("green_energy_exports", "TAS", "SUMMER", "B68:AG73"), ("green_energy_exports", "TAS", "WINTER", "B77:AG82"),
+    ("green_energy_exports", "VIC", "SUMMER", "B87:AG92"), ("green_energy_exports", "VIC", "WINTER", "B96:AG101"),
+]
+
+slug(s) = replace(lowercase(String(s)), r"[^a-z0-9]+" => "_")
+function cases(data_root)
+    c = Case[Case(id, Symbol(id), ISP24, sheet, range) for (id, sheet, range) in CORE_CASES]
+    push!(c, Case("legacy_generator_minimum_up_time", :legacy_generator_minimum_up_time, ISP19, "Generation limits", "O9:Q69"))
+    for (scenario, region, season, range) in DSP_CASES
+        source_id = Symbol("dsp_$(scenario)_$(lowercase(region))_$(lowercase(season))")
+        push!(c, Case("dsp_$(scenario)_$(region)_$(season)", source_id, ISP24, "DSP", range))
+    end
+    for (kind, source_id, workbook) in (
+        ("capacity", :vpp_capacity_outlook, "Auxiliary/StorageCapacityOutlook_2024_ISP.xlsx"),
+        ("energy", :vpp_energy_outlook, "Auxiliary/StorageEnergyOutlook_2024_ISP.xlsx"),
+    )
+        for scenario in SCENARIOS
+            push!(c, Case("vpp_$(kind)_$(slug(scenario))", source_id, workbook, scenario, "A1:AG1769"))
+        end
+    end
+    push!(c, Case("hydro_scheme_inflows", :hydro_scheme_inflows, ISP24, "Hydro Scheme Inflows", "B34:N47"))
+    push!(c, Case("ev_bev_phev_profile_weekend", :ev_bev_phev_profile_weekend, "2023-iasr-ev-workbook.xlsx", "BEV_PHEV_Profile_kW (Weekend)", "B:AY"))
+    push!(c, Case("ev_bev_phev_profile_weekday", :ev_bev_phev_profile_weekday, "2023-iasr-ev-workbook.xlsx", "BEV_PHEV_Profile_kW (Weekday)", "B:AY"))
+    push!(c, Case("ev_bev_phev_charge_type", :ev_bev_phev_charge_type, "2023-iasr-ev-workbook.xlsx", "BEV_PHEV_Charge_Type (%)", "B:BF"))
+    push!(c, Case("ev_subregional_demand_allocation", :ev_subregional_demand_allocation, ISP24, "Sub-regional demand allocation", "B127:AG182"))
+    ev = joinpath(data_root, "2023-iasr-ev-workbook.xlsx")
+    if isfile(ev)
+        sheets = XLSX.openxlsx(ev) do xf
+            sort!(filter(s -> endswith(s, "_Numbers"), XLSX.sheetnames(xf)))
+        end
+        for sheet in sheets
+            push!(c, Case("ev_vehicle_numbers_$(slug(sheet))", :ev_vehicle_numbers, "2023-iasr-ev-workbook.xlsx", sheet, "B:AZ"))
+        end
+    end
+    push!(c, Case("buildout_schedule", :buildout_schedule, "PISP-buildouts/buildouts.xlsx", "buildout_1", nothing))
+    core = joinpath(data_root, "Core")
+    if isdir(core)
+        for file in sort(filter(f -> endswith(lowercase(f), ".xlsx"), readdir(core)))
+            stem = slug(file)
+            for (id, sheet) in (("capacity", "Capacity"), ("storage_energy", "Storage Energy"),
+                                ("storage_capacity", "Storage Capacity"), ("rez_generation_capacity", "REZ Generation Capacity"))
+                source_id = Dict("capacity" => :core_capacity_outlook,
+                                 "storage_energy" => :core_storage_energy_outlook,
+                                 "storage_capacity" => :core_storage_capacity_outlook,
+                                 "rez_generation_capacity" => :core_rez_generation_capacity)[id]
+                push!(c, Case("core_$(id)_$(stem)", source_id, "Core/$file", sheet, "A3:AG5000";
+                             replacements=(core_workbook=file,)))
+            end
+        end
+    end
+    aux = joinpath(data_root, "Auxiliary")
+    if isdir(aux)
+        for file in sort(filter(f -> endswith(lowercase(f), ".xlsx") &&
+                                (occursin("Condensed", f) || occursin("REZCAP", f)), readdir(aux)))
+            path = joinpath(aux, file); stem = slug(file)
+            sheets = XLSX.openxlsx(path) do xf; sort!(XLSX.sheetnames(xf)); end
+            for sheet in sheets
+                is_rez = occursin("REZCAP", file)
+                source_id = is_rez ? :auxiliary_rez_generation_capacity : :condensed_capacity_outlook
+                range = is_rez ? "A1:AG2238" : "A1:G14356"
+                replacements = is_rez ? (scenario=strip(replace(file,
+                    "2024 ISP - " => "", " - Core_REZCAP.xlsx" => "")),) : (;)
+                push!(c, Case("aux_$(stem)_$(slug(sheet))", source_id, "Auxiliary/$file", sheet, range;
+                             replacements=replacements))
+            end
+        end
+    end
+    return c
+end
+
+function raw_df(path, sheet, range)
+    data = XLSX.readdata(path, sheet, range)
+    header = [ismissing(x) || x == "" ? "Column_$i" : string(x) for (i, x) in enumerate(data[1, :])]
+    return DataFrame(data[2:end, :], Symbol.(header); makeunique=true)
+end
+
+function whole_df(path, sheet)
+    data = XLSX.openxlsx(path) do xf; XLSX.getdata(xf[sheet]); end
+    return DataFrame(data[2:end, :], Symbol.(string.(data[1, :])); makeunique=true)
+end
+
+function literal_read(root, case)
+    path = joinpath(root, case.workbook)
+    case.range === nothing ? whole_df(path, case.worksheet) : PISP.read_xlsx_with_header(path, case.worksheet, case.range)
+end
+
+function spec_read(root, case)
+    spec = PISP.source_spec(case.source_id, 2024)
+    replacements = (; case.replacements...)
+    path = PISP.source_path(root, spec; replacements...)
+    if spec.cell_range === nothing
+        return whole_df(path, case.worksheet)
+    end
+    return PISP.read_xlsx_with_header(path, spec; worksheet=case.worksheet)
+end
+
+function record(case, df, root, output_dir)
+    io = IOBuffer(); CSV.write(io, df); bytes = take!(io)
+    Dict("case_id" => case.id, "relative_file" => case.workbook, "worksheet" => case.worksheet,
+         "range" => something(case.range, "whole-sheet"), "rows" => nrow(df), "columns" => ncol(df),
+         "column_names" => String.(names(df)), "sha256" => bytes2hex(sha256(bytes)))
+end
+
+function write_manifest(path, records, skips)
+    mkpath(dirname(path)); open(path, "w") do io
+        TOML.print(io, Dict("cases" => records, "skips" => skips))
+    end
+end
+
+function run_mode(mode, root, output)
+    use_specs = mode == "specs"
+    recs = Dict{String,Any}[]; skips = Dict{String,Any}[]
+    for case in cases(root)
+        path = joinpath(root, case.workbook)
+        if !isfile(path)
+            push!(skips, Dict("case_id" => case.id, "reason" => "missing workbook: $(case.workbook)")); continue
+        end
+        try
+            df = use_specs ? spec_read(root, case) : literal_read(root, case)
+            push!(recs, record(case, df, root, dirname(output)))
+        catch err
+            push!(skips, Dict("case_id" => case.id, "reason" => sprint(showerror, err)))
+        end
+    end
+    sort!(recs; by=x -> x["case_id"]); sort!(skips; by=x -> x["case_id"])
+    write_manifest(output, recs, skips)
+    println("wrote $(length(recs)) cases and $(length(skips)) skips to $output")
+end
+
+function compare_manifests(a, b)
+    left, right = TOML.parsefile(a), TOML.parsefile(b)
+    l = Dict(x["case_id"] => x for x in get(left, "cases", Any[])); r = Dict(x["case_id"] => x for x in get(right, "cases", Any[]))
+    mismatches = String[]
+    for id in sort!(collect(union(keys(l), keys(r))))
+        haskey(l, id) && haskey(r, id) || (push!(mismatches, "$id: case present in only one manifest"); continue)
+        for field in ("rows", "columns", "column_names", "sha256")
+            l[id][field] == r[id][field] || push!(mismatches, "$id: $field differs ($(l[id][field]) vs $(r[id][field]))")
+        end
+    end
+    for message in mismatches; println(message); end
+    isempty(mismatches) && println("manifests match ($(length(l)) cases)")
+    return isempty(mismatches)
+end
+
+function main(args)
+    isempty(args) && error("usage: legacy|specs --data-root PATH --output PATH, or compare --baseline PATH --candidate PATH")
+    mode = args[1]; mode in ("legacy", "specs", "compare") || error("unknown mode: $mode")
+    opts = Dict{String,String}(); i = 2
+    while i <= length(args)
+        startswith(args[i], "--") || error("expected option, got $(args[i])")
+        i == length(args) && error("missing value for $(args[i])")
+        opts[args[i][3:end]] = args[i + 1]; i += 2
+    end
+    if mode == "compare"
+        haskey(opts, "baseline") && haskey(opts, "candidate") || error("compare requires --baseline and --candidate")
+        compare_manifests(opts["baseline"], opts["candidate"]) || exit(1)
+    else
+        haskey(opts, "data-root") && haskey(opts, "output") || error("$mode requires --data-root and --output")
+        run_mode(mode, opts["data-root"], opts["output"])
+    end
+end
+
+main(ARGS)

--- a/src/PISP.jl
+++ b/src/PISP.jl
@@ -9,12 +9,36 @@ module PISP
 
     include("PISPdatamodel.jl")
     include("PISPstructures.jl")
+    include("PISPsource_specs.jl")
     include("PISPutils.jl")
     include("PISPparameters.jl")
     include("PISPparsers.jl")
     include("PISPscrappers.jl")
 
-    export build_pipeline,
+    export SourceSpec,
+        XlsxSourceSpec,
+        CsvSourceSpec,
+        ColumnSpec,
+        SourceSpecRegistry,
+        SourceSpecDiff,
+        SOURCE_SPECS,
+        register_source_specs!,
+        source_specs,
+        source_spec,
+        source_spec_registry,
+        resolve_source_pattern,
+        source_path,
+        compare_source_specs,
+        source_spec_records,
+        source_spec_rows,
+        source_spec_diff_rows,
+        export_source_specs,
+        export_source_spec_diff,
+        read_xlsx_rows,
+        read_xlsx_with_header,
+        read_csv_source,
+        validate_source_columns,
+        build_pipeline,
         download_ISP24_reports,
         download_ISP26_reports,
         download_isp2026_assets

--- a/src/PISPsource_specs.jl
+++ b/src/PISPsource_specs.jl
@@ -1,0 +1,631 @@
+"""Common abstraction for one semantic PISP source definition."""
+abstract type SourceSpec end
+
+"""Expected column metadata for a source table."""
+struct ColumnSpec
+    name::String
+    required::Bool
+    data_type::Union{Nothing,Symbol}
+    unit::Union{Nothing,String}
+    description::String
+end
+
+function ColumnSpec(;
+    name,
+    required::Bool = true,
+    data_type = nothing,
+    unit = nothing,
+    description = "",
+)
+    column_name = strip(string(name))
+    isempty(column_name) && throw(ArgumentError("ColumnSpec.name must not be empty."))
+
+    return ColumnSpec(
+        column_name,
+        required,
+        data_type === nothing ? nothing : Symbol(data_type),
+        unit === nothing ? nothing : strip(string(unit)),
+        strip(string(description)),
+    )
+end
+
+"""Excel workbook source location and expected table schema."""
+struct XlsxSourceSpec <: SourceSpec
+    id::Symbol
+    edition::Int
+    workbook::String
+    worksheet::String
+    cell_range::Union{Nothing,String}
+    description::String
+    columns::Vector{ColumnSpec}
+    source_family::Symbol
+    consumer::Union{Nothing,Symbol}
+end
+
+function XlsxSourceSpec(;
+    id,
+    edition,
+    workbook,
+    worksheet,
+    cell_range = nothing,
+    description,
+    columns = ColumnSpec[],
+    source_family = :unspecified,
+    consumer = nothing,
+)
+    spec = XlsxSourceSpec(
+        Symbol(id),
+        Int(edition),
+        strip(string(workbook)),
+        strip(string(worksheet)),
+        cell_range === nothing ? nothing : strip(string(cell_range)),
+        strip(string(description)),
+        ColumnSpec[columns...],
+        Symbol(source_family),
+        consumer === nothing ? nothing : Symbol(consumer),
+    )
+    return validate_source_spec(spec)
+end
+
+"""CSV filename selection and expected table schema."""
+struct CsvSourceSpec <: SourceSpec
+    id::Symbol
+    edition::Int
+    filename_pattern::String
+    description::String
+    columns::Vector{ColumnSpec}
+    keys::Vector{String}
+    source_family::Symbol
+    consumer::Union{Nothing,Symbol}
+end
+
+function CsvSourceSpec(;
+    id,
+    edition,
+    filename_pattern,
+    description,
+    columns = ColumnSpec[],
+    keys = String[],
+    source_family = :unspecified,
+    consumer = nothing,
+)
+    spec = CsvSourceSpec(
+        Symbol(id),
+        Int(edition),
+        strip(string(filename_pattern)),
+        strip(string(description)),
+        ColumnSpec[columns...],
+        string.(keys),
+        Symbol(source_family),
+        consumer === nothing ? nothing : Symbol(consumer),
+    )
+    return validate_source_spec(spec)
+end
+
+"""Validated collection of source definitions for one ISP edition."""
+struct SourceSpecRegistry
+    edition::Int
+    specs::Vector{SourceSpec}
+
+    function SourceSpecRegistry(edition::Integer, specs::AbstractVector{<:SourceSpec})
+        registry_edition = Int(edition)
+        registered = SourceSpec[specs...]
+        all(spec -> spec.edition == registry_edition, registered) ||
+            throw(ArgumentError("Every source specification must match registry edition $(registry_edition)."))
+
+        ids = getfield.(registered, :id)
+        length(ids) == length(unique(ids)) ||
+            throw(ArgumentError("Source specification identifiers must be unique within edition $(registry_edition)."))
+
+        foreach(validate_source_spec, registered)
+        sort!(registered; by = spec -> string(spec.id))
+        new(registry_edition, registered)
+    end
+end
+
+"""Structural comparison of one semantic source between two ISP editions."""
+struct SourceSpecDiff
+    id::Symbol
+    source_family::Symbol
+    status::Symbol
+    previous::Union{Nothing,SourceSpec}
+    current::Union{Nothing,SourceSpec}
+    columns_added::Vector{String}
+    columns_removed::Vector{String}
+    units_changed::Vector{String}
+    types_changed::Vector{String}
+end
+
+const SOURCE_SPECS = SourceSpec[]
+
+source_format(::XlsxSourceSpec) = :xlsx
+source_format(::CsvSourceSpec) = :csv
+
+function resolve_source_pattern(pattern::AbstractString; replacements...)
+    resolved = String(pattern)
+    for (name, value) in replacements
+        resolved = replace(resolved, "{$(name)}" => string(value))
+    end
+
+    unresolved = match(r"\{[^{}]+\}", resolved)
+    unresolved === nothing || throw(ArgumentError(
+        "Unresolved source-pattern token $(unresolved.match) in `$(pattern)`.",
+    ))
+    return resolved
+end
+
+source_path(root::AbstractString, spec::XlsxSourceSpec; replacements...) =
+    normpath(root, resolve_source_pattern(spec.workbook; replacements...))
+
+source_path(root::AbstractString, spec::CsvSourceSpec; replacements...) =
+    normpath(root, resolve_source_pattern(spec.filename_pattern; replacements...))
+
+function is_valid_excel_range(cell_range::AbstractString)
+    return occursin(
+        r"^\$?[A-Za-z]{1,3}(?:\$?\d+)?(?::\$?[A-Za-z]{1,3}(?:\$?\d+)?)?$",
+        cell_range,
+    )
+end
+
+function _validate_columns(columns::Vector{ColumnSpec}, source_id::Symbol)
+    names = getfield.(columns, :name)
+    length(names) == length(unique(names)) ||
+        throw(ArgumentError("Column names must be unique within source specification $(source_id)."))
+    return nothing
+end
+
+function validate_source_spec(spec::XlsxSourceSpec)
+    spec.edition > 0 || throw(ArgumentError("Source specification edition must be positive."))
+    isempty(string(spec.id)) && throw(ArgumentError("XlsxSourceSpec.id must not be empty."))
+    isempty(spec.workbook) && throw(ArgumentError("XlsxSourceSpec.workbook must not be empty."))
+    isempty(spec.worksheet) && throw(ArgumentError("XlsxSourceSpec.worksheet must not be empty."))
+    isempty(spec.description) && throw(ArgumentError("XlsxSourceSpec.description must not be empty."))
+    spec.source_family == :unspecified &&
+        throw(ArgumentError("XlsxSourceSpec.source_family must be specified for source $(spec.id)."))
+    spec.cell_range === nothing || is_valid_excel_range(spec.cell_range) ||
+        throw(ArgumentError("Invalid Excel range `$(spec.cell_range)` for source $(spec.id)."))
+    _validate_columns(spec.columns, spec.id)
+    return spec
+end
+
+function validate_source_spec(spec::CsvSourceSpec)
+    spec.edition > 0 || throw(ArgumentError("Source specification edition must be positive."))
+    isempty(string(spec.id)) && throw(ArgumentError("CsvSourceSpec.id must not be empty."))
+    isempty(spec.filename_pattern) &&
+        throw(ArgumentError("CsvSourceSpec.filename_pattern must not be empty."))
+    isempty(spec.description) && throw(ArgumentError("CsvSourceSpec.description must not be empty."))
+    spec.source_family == :unspecified &&
+        throw(ArgumentError("CsvSourceSpec.source_family must be specified for source $(spec.id)."))
+    length(spec.keys) == length(unique(spec.keys)) ||
+        throw(ArgumentError("CSV keys must be unique within source specification $(spec.id)."))
+    _validate_columns(spec.columns, spec.id)
+    if !isempty(spec.columns)
+        column_names = Set(getfield.(spec.columns, :name))
+        unknown_keys = setdiff(Set(spec.keys), column_names)
+        isempty(unknown_keys) || throw(ArgumentError(
+            "CSV keys must be declared as columns for source $(spec.id): " *
+            join(sort!(collect(unknown_keys)), ", "),
+        ))
+    end
+    return spec
+end
+
+function register_source_specs!(specs::SourceSpec...)
+    seen = Set((spec.edition, spec.id) for spec in SOURCE_SPECS)
+    for spec in specs
+        validate_source_spec(spec)
+        key = (spec.edition, spec.id)
+        key in seen && throw(ArgumentError(
+            "Source specification $(spec.id) is already registered for edition $(spec.edition).",
+        ))
+        push!(seen, key)
+    end
+    append!(SOURCE_SPECS, specs)
+    return nothing
+end
+
+source_specs(edition::Integer) = source_specs(Val(Int(edition)))
+function source_specs(::Val{E}) where {E}
+    specs = SourceSpec[spec for spec in SOURCE_SPECS if spec.edition == Int(E)]
+    return sort!(specs; by = spec -> string(spec.id))
+end
+
+source_spec_registry(edition::Integer) = source_spec_registry(Val(Int(edition)))
+source_spec_registry(::Val{E}) where {E} = SourceSpecRegistry(Int(E), source_specs(Val(E)))
+
+function source_spec(id, edition::Integer)
+    source_id = Symbol(id)
+    matches = filter(spec -> spec.id == source_id, source_specs(edition))
+    isempty(matches) && throw(KeyError((edition, source_id)))
+    return only(matches)
+end
+
+function _source_location(spec::XlsxSourceSpec)
+    return (spec.workbook, spec.worksheet, spec.cell_range)
+end
+
+_source_location(spec::CsvSourceSpec) = (spec.filename_pattern,)
+
+_column_signature(column::ColumnSpec) = (
+    column.name,
+    column.required,
+    column.data_type,
+    column.unit,
+    column.description,
+)
+
+_source_schema(spec::XlsxSourceSpec) = (_column_signature.(spec.columns),)
+_source_schema(spec::CsvSourceSpec) = (_column_signature.(spec.columns), spec.keys)
+
+function _column_changes(previous::SourceSpec, current::SourceSpec)
+    previous_columns = Dict(column.name => column for column in previous.columns)
+    current_columns = Dict(column.name => column for column in current.columns)
+    previous_names = Set(keys(previous_columns))
+    current_names = Set(keys(current_columns))
+
+    columns_added = sort!(collect(setdiff(current_names, previous_names)))
+    columns_removed = sort!(collect(setdiff(previous_names, current_names)))
+    common_names = sort!(collect(intersect(previous_names, current_names)))
+
+    units_changed = String[]
+    types_changed = String[]
+    for name in common_names
+        old_column = previous_columns[name]
+        new_column = current_columns[name]
+        old_column.unit == new_column.unit || push!(
+            units_changed,
+            "$(name): $(something(old_column.unit, "nothing")) -> $(something(new_column.unit, "nothing"))",
+        )
+        old_column.data_type == new_column.data_type || push!(
+            types_changed,
+            "$(name): $(something(old_column.data_type, :nothing)) -> $(something(new_column.data_type, :nothing))",
+        )
+    end
+
+    return columns_added, columns_removed, units_changed, types_changed
+end
+
+function compare_source_specs(
+    previous::SourceSpecRegistry,
+    current::SourceSpecRegistry,
+)
+    previous_by_id = Dict(spec.id => spec for spec in previous.specs)
+    current_by_id = Dict(spec.id => spec for spec in current.specs)
+    source_ids = sort!(
+        unique(vcat(collect(keys(previous_by_id)), collect(keys(current_by_id))));
+        by = string,
+    )
+    diffs = SourceSpecDiff[]
+
+    for source_id in source_ids
+        previous_spec = get(previous_by_id, source_id, nothing)
+        current_spec = get(current_by_id, source_id, nothing)
+
+        if previous_spec === nothing
+            push!(diffs, SourceSpecDiff(
+                source_id,
+                current_spec.source_family,
+                :added,
+                nothing,
+                current_spec,
+                sort!(getfield.(current_spec.columns, :name)),
+                String[],
+                String[],
+                String[],
+            ))
+            continue
+        elseif current_spec === nothing
+            push!(diffs, SourceSpecDiff(
+                source_id,
+                previous_spec.source_family,
+                :removed,
+                previous_spec,
+                nothing,
+                String[],
+                sort!(getfield.(previous_spec.columns, :name)),
+                String[],
+                String[],
+            ))
+            continue
+        end
+
+        columns_added, columns_removed, units_changed, types_changed =
+            _column_changes(previous_spec, current_spec)
+        location_changed = source_format(previous_spec) != source_format(current_spec) ||
+            _source_location(previous_spec) != _source_location(current_spec)
+        schema_changed = _source_schema(previous_spec) != _source_schema(current_spec)
+        status = if !location_changed && !schema_changed
+            :unchanged
+        elseif location_changed && !schema_changed
+            :location_changed
+        elseif !location_changed && schema_changed
+            :schema_changed
+        else
+            :manual_review_required
+        end
+
+        push!(diffs, SourceSpecDiff(
+            source_id,
+            current_spec.source_family,
+            status,
+            previous_spec,
+            current_spec,
+            columns_added,
+            columns_removed,
+            units_changed,
+            types_changed,
+        ))
+    end
+
+    return diffs
+end
+
+compare_source_specs(previous::Integer, current::Integer) = compare_source_specs(
+    source_spec_registry(previous),
+    source_spec_registry(current),
+)
+
+_column_record(column::ColumnSpec) = (
+    name = column.name,
+    required = column.required,
+    data_type = column.data_type === nothing ? nothing : string(column.data_type),
+    unit = column.unit,
+    description = column.description,
+)
+
+function source_spec_record(spec::XlsxSourceSpec)
+    return (
+        id = string(spec.id),
+        edition = spec.edition,
+        source_format = "xlsx",
+        workbook = spec.workbook,
+        worksheet = spec.worksheet,
+        cell_range = spec.cell_range,
+        filename_pattern = nothing,
+        description = spec.description,
+        columns = _column_record.(spec.columns),
+        keys = String[],
+        source_family = string(spec.source_family),
+        consumer = spec.consumer === nothing ? nothing : string(spec.consumer),
+    )
+end
+
+function source_spec_record(spec::CsvSourceSpec)
+    return (
+        id = string(spec.id),
+        edition = spec.edition,
+        source_format = "csv",
+        workbook = nothing,
+        worksheet = nothing,
+        cell_range = nothing,
+        filename_pattern = spec.filename_pattern,
+        description = spec.description,
+        columns = _column_record.(spec.columns),
+        keys = copy(spec.keys),
+        source_family = string(spec.source_family),
+        consumer = spec.consumer === nothing ? nothing : string(spec.consumer),
+    )
+end
+
+source_spec_records(registry::SourceSpecRegistry) = source_spec_record.(registry.specs)
+source_spec_records(edition::Integer) = source_spec_records(source_spec_registry(edition))
+
+function _column_summary(columns::Vector{ColumnSpec})
+    return join((column.required ? column.name : "$(column.name)?" for column in columns), "; ")
+end
+
+function _unit_summary(columns::Vector{ColumnSpec})
+    return join(("$(column.name)=$(column.unit)" for column in columns if column.unit !== nothing), "; ")
+end
+
+function source_spec_row(spec::XlsxSourceSpec)
+    return (
+        id = string(spec.id),
+        edition = spec.edition,
+        source_format = "xlsx",
+        workbook_or_pattern = spec.workbook,
+        worksheet = spec.worksheet,
+        cell_range = something(spec.cell_range, ""),
+        columns = _column_summary(spec.columns),
+        units = _unit_summary(spec.columns),
+        keys = "",
+        source_family = string(spec.source_family),
+        consumer = spec.consumer === nothing ? "" : string(spec.consumer),
+        description = spec.description,
+    )
+end
+
+function source_spec_row(spec::CsvSourceSpec)
+    return (
+        id = string(spec.id),
+        edition = spec.edition,
+        source_format = "csv",
+        workbook_or_pattern = spec.filename_pattern,
+        worksheet = "",
+        cell_range = "",
+        columns = _column_summary(spec.columns),
+        units = _unit_summary(spec.columns),
+        keys = join(spec.keys, "; "),
+        source_family = string(spec.source_family),
+        consumer = spec.consumer === nothing ? "" : string(spec.consumer),
+        description = spec.description,
+    )
+end
+
+source_spec_rows(registry::SourceSpecRegistry) = source_spec_row.(registry.specs)
+source_spec_rows(edition::Integer) = source_spec_rows(source_spec_registry(edition))
+
+_optional_location(spec::Nothing, field::Symbol) = ""
+function _optional_location(spec::XlsxSourceSpec, field::Symbol)
+    value = getfield(spec, field)
+    return value === nothing ? "" : string(value)
+end
+_optional_location(spec::CsvSourceSpec, field::Symbol) = field == :workbook ? spec.filename_pattern : ""
+
+function source_spec_diff_row(diff::SourceSpecDiff)
+    return (
+        source_id = string(diff.id),
+        source_family = string(diff.source_family),
+        status = string(diff.status),
+        workbook_previous = _optional_location(diff.previous, :workbook),
+        workbook_current = _optional_location(diff.current, :workbook),
+        worksheet_previous = _optional_location(diff.previous, :worksheet),
+        worksheet_current = _optional_location(diff.current, :worksheet),
+        range_previous = _optional_location(diff.previous, :cell_range),
+        range_current = _optional_location(diff.current, :cell_range),
+        columns_added = join(diff.columns_added, "; "),
+        columns_removed = join(diff.columns_removed, "; "),
+        units_changed = join(diff.units_changed, "; "),
+        types_changed = join(diff.types_changed, "; "),
+        description = something(
+            diff.current === nothing ? nothing : diff.current.description,
+            diff.previous === nothing ? "" : diff.previous.description,
+        ),
+    )
+end
+
+source_spec_diff_rows(diffs::AbstractVector{SourceSpecDiff}) = source_spec_diff_row.(diffs)
+
+function _normalise_export_format(format)
+    value = Symbol(lowercase(string(format)))
+    value == :md && return :markdown
+    value in (:json, :csv, :markdown) ||
+        throw(ArgumentError("Unsupported source-spec export format: $(format)."))
+    return value
+end
+
+function _export_format_from_path(path::AbstractString)
+    extension = lowercase(splitext(path)[2])
+    extension == ".json" && return :json
+    extension == ".csv" && return :csv
+    extension in (".md", ".markdown") && return :markdown
+    throw(ArgumentError("Cannot infer source-spec export format from path `$(path)`."))
+end
+
+function _json_escape(value::AbstractString)
+    return replace(
+        value,
+        "\\" => "\\\\",
+        "\"" => "\\\"",
+        "\n" => "\\n",
+        "\r" => "\\r",
+        "\t" => "\\t",
+    )
+end
+
+function _write_json_value(io::IO, value, indent::Int = 0)
+    if value === nothing
+        print(io, "null")
+    elseif value isa Bool
+        print(io, value ? "true" : "false")
+    elseif value isa Number
+        print(io, value)
+    elseif value isa Symbol
+        print(io, '"', _json_escape(string(value)), '"')
+    elseif value isa AbstractString
+        print(io, '"', _json_escape(value), '"')
+    elseif value isa NamedTuple
+        names = collect(keys(value))
+        println(io, "{")
+        for (index, name) in enumerate(names)
+            print(io, repeat(" ", indent + 2), '"', _json_escape(string(name)), "\": ")
+            _write_json_value(io, getfield(value, name), indent + 2)
+            index == length(names) || print(io, ',')
+            println(io)
+        end
+        print(io, repeat(" ", indent), "}")
+    elseif value isa AbstractVector || value isa Tuple
+        isempty(value) && return print(io, "[]")
+        println(io, "[")
+        for (index, item) in enumerate(value)
+            print(io, repeat(" ", indent + 2))
+            _write_json_value(io, item, indent + 2)
+            index == length(value) || print(io, ',')
+            println(io)
+        end
+        print(io, repeat(" ", indent), "]")
+    else
+        throw(ArgumentError("Unsupported JSON value type $(typeof(value))."))
+    end
+end
+
+function _csv_cell(value)
+    text = value === nothing ? "" : string(value)
+    escaped = replace(text, '"' => "\"\"")
+    if any(character -> character in (',', '"', '\n', '\r'), escaped)
+        return "\"$(escaped)\""
+    end
+    return escaped
+end
+
+function _write_csv(io::IO, rows)
+    isempty(rows) && return nothing
+    headings = collect(keys(first(rows)))
+    println(io, join(_csv_cell.(headings), ","))
+    for row in rows
+        println(io, join((_csv_cell(getfield(row, heading)) for heading in headings), ","))
+    end
+    return nothing
+end
+
+function _markdown_cell(value)
+    text = value === nothing ? "" : string(value)
+    return replace(text, "|" => "\\|", "\n" => "<br>", "\r" => "")
+end
+
+function _write_markdown(io::IO, rows)
+    isempty(rows) && return nothing
+    headings = collect(keys(first(rows)))
+    println(io, "| ", join(_markdown_cell.(headings), " | "), " |")
+    println(io, "| ", join(fill("---", length(headings)), " | "), " |")
+    for row in rows
+        println(io, "| ", join((_markdown_cell(getfield(row, heading)) for heading in headings), " | "), " |")
+    end
+    return nothing
+end
+
+function _write_source_spec_export(path::AbstractString, format::Symbol, records, rows)
+    output_path = normpath(path)
+    mkpath(dirname(output_path))
+    open(output_path, "w") do io
+        if format == :json
+            _write_json_value(io, records)
+            println(io)
+        elseif format == :csv
+            _write_csv(io, rows)
+        else
+            _write_markdown(io, rows)
+        end
+    end
+    return output_path
+end
+
+function export_source_specs(
+    path::AbstractString,
+    registry::SourceSpecRegistry;
+    format = _export_format_from_path(path),
+)
+    export_format = _normalise_export_format(format)
+    return _write_source_spec_export(
+        path,
+        export_format,
+        source_spec_records(registry),
+        source_spec_rows(registry),
+    )
+end
+
+export_source_specs(path::AbstractString, edition::Integer; kwargs...) =
+    export_source_specs(path, source_spec_registry(edition); kwargs...)
+
+function export_source_spec_diff(
+    path::AbstractString,
+    diffs::AbstractVector{SourceSpecDiff};
+    format = _export_format_from_path(path),
+)
+    export_format = _normalise_export_format(format)
+    rows = source_spec_diff_rows(diffs)
+    return _write_source_spec_export(path, export_format, rows, rows)
+end
+
+export_source_spec_diff(path::AbstractString, previous::Integer, current::Integer; kwargs...) =
+    export_source_spec_diff(path, compare_source_specs(previous, current); kwargs...)

--- a/src/parsers/PISP-2024buildout.jl
+++ b/src/parsers/PISP-2024buildout.jl
@@ -1,7 +1,7 @@
 const ISP2024_BUILDOUT_TABLE_SOURCE = XlsxSourceSpec(
     id = :buildout_schedule,
     edition = 2024,
-    workbook = "{buildout_workbook}",
+    workbook = "PISP-buildouts/buildouts.xlsx",
     worksheet = "buildout_1",
     cell_range = nothing,
     description = "User-provided generation and storage buildout schedule.",

--- a/src/parsers/PISP-2024buildout.jl
+++ b/src/parsers/PISP-2024buildout.jl
@@ -1,3 +1,23 @@
+const ISP2024_BUILDOUT_TABLE_SOURCE = XlsxSourceSpec(
+    id = :buildout_schedule,
+    edition = 2024,
+    workbook = "{buildout_workbook}",
+    worksheet = "buildout_1",
+    cell_range = nothing,
+    description = "User-provided generation and storage buildout schedule.",
+    columns = ColumnSpec[
+        ColumnSpec(name = "tech"),
+        ColumnSpec(name = "subregion"),
+        ColumnSpec(name = "year", data_type = :Integer),
+        ColumnSpec(name = "capacity", data_type = :Real, unit = "MW"),
+        ColumnSpec(name = "n", data_type = :Integer),
+    ],
+    source_family = :buildout,
+    consumer = :read_buildout_table,
+)
+
+register_source_specs!(ISP2024_BUILDOUT_TABLE_SOURCE)
+
 """
     read_buildout_table(filepath; sheetname) → (static_data, tvarying_data)
 
@@ -7,11 +27,16 @@ Parse a buildout schedule workbook sheet and return two DataFrames:
 
 `name` is `uppercase(tech * "_" * subregion) * "_NEW"`.
 """
-function read_buildout_table(filepath::AbstractString; sheetname::AbstractString="buildout_1")
+function read_buildout_table(
+    filepath::AbstractString;
+    source_spec::XlsxSourceSpec = ISP2024_BUILDOUT_TABLE_SOURCE,
+    sheetname::AbstractString = source_spec.worksheet,
+)
     raw = XLSX.openxlsx(filepath) do xf
         data = XLSX.getdata(xf[sheetname])
         DataFrame(data[2:end, :], Symbol.(vec(data[1, :])))
     end
+    validate_source_columns(raw, source_spec)
 
     raw.tech      = String.(raw.tech)
     raw.subregion = String.(raw.subregion)

--- a/src/parsers/PISP-2024parser.jl
+++ b/src/parsers/PISP-2024parser.jl
@@ -1,3 +1,491 @@
+const ISP2024_INPUTS_WORKBOOK = "2024-isp-inputs-and-assumptions-workbook.xlsx"
+const ISP2019_INPUTS_WORKBOOK = "2019-input-and-assumptions-workbook-v1-3-dec-19.xlsx"
+const ISP2024_CONDENSED_CAPACITY_WORKBOOK = "Auxiliary/CapacityOutlook2024_Condensed.xlsx"
+const ISP2024_REZ_CAPACITY_WORKBOOK_PATTERN = "Auxiliary/2024 ISP - {scenario} - Core_REZCAP.xlsx"
+const ISP2024_VPP_CAPACITY_WORKBOOK = "Auxiliary/StorageCapacityOutlook_2024_ISP.xlsx"
+const ISP2024_VPP_ENERGY_WORKBOOK = "Auxiliary/StorageEnergyOutlook_2024_ISP.xlsx"
+
+_source_spec_slug(value) = replace(lowercase(strip(string(value))), r"[^a-z0-9]+" => "_")
+
+function _isp2024_xlsx_source(;
+    id,
+    worksheet,
+    cell_range,
+    description,
+    source_family,
+    consumer,
+    workbook = ISP2024_INPUTS_WORKBOOK,
+    columns = ColumnSpec[],
+)
+    return XlsxSourceSpec(
+        id = id,
+        edition = 2024,
+        workbook = workbook,
+        worksheet = worksheet,
+        cell_range = cell_range,
+        description = description,
+        columns = columns,
+        source_family = source_family,
+        consumer = consumer,
+    )
+end
+
+const ISP2024_TRACE_DATE_COLUMNS = ColumnSpec[
+    ColumnSpec(name = "Year", data_type = :Integer),
+    ColumnSpec(name = "Month", data_type = :Integer),
+    ColumnSpec(name = "Day", data_type = :Integer),
+]
+
+const ISP2024_NETWORK_CAPABILITY_SOURCE = _isp2024_xlsx_source(
+    id = :network_capability,
+    worksheet = "Network Capability",
+    cell_range = "B6:H21",
+    description = "Forward and reverse transfer capability assumptions for ISP flow paths.",
+    source_family = :network,
+    consumer = :line_table,
+)
+const ISP2024_TRANSMISSION_RELIABILITY_SOURCE = _isp2024_xlsx_source(
+    id = :transmission_reliability,
+    worksheet = "Transmission Reliability",
+    cell_range = "B7:G11",
+    description = "Transmission reliability assumptions applied to inter-regional flow paths.",
+    source_family = :network,
+    consumer = :line_table,
+)
+const ISP2024_FLOW_PATH_AUGMENTATION_SOURCE = _isp2024_xlsx_source(
+    id = :flow_path_augmentation_options,
+    worksheet = "Flow Path Augmentation options",
+    cell_range = "B11:N94",
+    description = "Candidate flow-path augmentations and their capability increments.",
+    source_family = :network,
+    consumer = :line_invoptions,
+)
+const ISP2024_GENERATOR_MAPPING_NAMES_SOURCE = _isp2024_xlsx_source(
+    id = :generator_summary_mapping_names,
+    worksheet = "Summary Mapping",
+    cell_range = "B6:B680",
+    description = "Generator identifiers used to align summary-mapping rows.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_GENERATOR_MAPPING_MLF_SOURCE = _isp2024_xlsx_source(
+    id = :generator_summary_mapping_mlf,
+    worksheet = "Summary Mapping",
+    cell_range = "AA6:AA680",
+    description = "Marginal-loss-factor values aligned with generator summary rows.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_EXISTING_GENERATOR_MAX_CAPACITY_SOURCE = _isp2024_xlsx_source(
+    id = :existing_generator_maximum_capacity,
+    worksheet = "Maximum capacity",
+    cell_range = "B8:D260",
+    description = "Maximum capacity assumptions for existing generating units.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_COMMITTED_GENERATOR_MAX_CAPACITY_SOURCE = _isp2024_xlsx_source(
+    id = :committed_generator_maximum_capacity,
+    worksheet = "Maximum capacity",
+    cell_range = "F8:I35",
+    description = "Maximum capacity assumptions for committed generation projects.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_ANTICIPATED_GENERATOR_MAX_CAPACITY_SOURCE = _isp2024_xlsx_source(
+    id = :anticipated_generator_maximum_capacity,
+    worksheet = "Maximum capacity",
+    cell_range = "K8:N24",
+    description = "Maximum capacity assumptions for anticipated generation projects.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_GENERATOR_SUMMARY_MAPPING_SOURCE = _isp2024_xlsx_source(
+    id = :generator_summary_mapping,
+    worksheet = "Summary Mapping",
+    cell_range = "B4:I680",
+    description = "Generator-to-summary mapping used during generator asset construction.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_COAL_MINIMUM_STABLE_GENERATION_SOURCE = _isp2024_xlsx_source(
+    id = :coal_minimum_stable_generation,
+    worksheet = "Generation limits",
+    cell_range = "B8:D52",
+    description = "Minimum stable generation assumptions for coal units.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_GPG_MINIMUM_STABLE_GENERATION_SOURCE = _isp2024_xlsx_source(
+    id = :gpg_minimum_stable_generation,
+    worksheet = "GPG Min Stable Level",
+    cell_range = "B9:E34",
+    description = "Minimum stable generation assumptions for gas-powered generation.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_GENERATOR_MIN_UP_DOWN_SOURCE = _isp2024_xlsx_source(
+    id = :generator_minimum_up_down_times,
+    worksheet = "Min Up&Down Times",
+    cell_range = "B8:E25",
+    description = "Minimum up- and down-time assumptions available in the 2024 workbook.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_LEGACY_GENERATOR_MIN_UP_SOURCE = _isp2024_xlsx_source(
+    id = :legacy_generator_minimum_up_time,
+    workbook = ISP2019_INPUTS_WORKBOOK,
+    worksheet = "Generation limits",
+    cell_range = "O9:Q69",
+    description = "Legacy 2019 unit-level minimum up times retained by the 2024 parser.",
+    columns = ColumnSpec[
+        ColumnSpec(name = "Generator Station"),
+        ColumnSpec(name = "Generating unit"),
+        ColumnSpec(name = "Min Up Time (hours)", data_type = :Real, unit = "h"),
+    ],
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_GENERATOR_RAMP_RATES_SOURCE = _isp2024_xlsx_source(
+    id = :generator_maximum_ramp_rates,
+    worksheet = "Max Ramp Rates",
+    cell_range = "B8:F72",
+    description = "Maximum ramp-rate assumptions for unit commitment parameters.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_GENERATOR_RETIREMENTS_SOURCE = _isp2024_xlsx_source(
+    id = :generator_retirements,
+    worksheet = "Retirement",
+    cell_range = "B9:D460",
+    description = "Generator retirement timing assumptions.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_EXISTING_GENERATOR_RELIABILITY_SOURCE = _isp2024_xlsx_source(
+    id = :existing_generator_reliability,
+    worksheet = "Generator Reliability Settings",
+    cell_range = "B20:G28",
+    description = "Reliability settings for existing generator technology groups.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_NEW_GENERATOR_RELIABILITY_SOURCE = _isp2024_xlsx_source(
+    id = :new_generator_reliability,
+    worksheet = "Generator Reliability Settings",
+    cell_range = "I20:N40",
+    description = "Reliability settings for new generator and storage technology groups.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_EXISTING_GENERATOR_SUMMARY_SOURCE = _isp2024_xlsx_source(
+    id = :existing_generator_summary,
+    worksheet = "Existing Gen Data Summary",
+    cell_range = "B10:U319",
+    description = "Primary existing-generator summary used to construct generator assets.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_ADDITIONAL_GENERATOR_SUMMARY_SOURCE = _isp2024_xlsx_source(
+    id = :additional_generator_summary,
+    worksheet = "Existing Gen Data Summary",
+    cell_range = "B382:U397",
+    description = "Additional generator summary rows appended to the primary existing fleet.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_GENERATOR_EMISSIONS_SOURCE = _isp2024_xlsx_source(
+    id = :generator_emissions_intensity,
+    worksheet = "Emissions intensity",
+    cell_range = "B7:D73",
+    description = "Generator emissions-intensity assumptions.",
+    source_family = :generation,
+    consumer = :generator_table,
+)
+const ISP2024_BESS_PROPERTIES_SOURCE = _isp2024_xlsx_source(
+    id = :bess_storage_properties,
+    worksheet = "Storage properties",
+    cell_range = "B4:H13",
+    description = "Battery storage efficiency, duration and operating-property assumptions.",
+    source_family = :storage,
+    consumer = :ess_tables,
+)
+const ISP2024_PUMPED_STORAGE_PROPERTIES_SOURCE = _isp2024_xlsx_source(
+    id = :pumped_storage_properties,
+    worksheet = "Storage properties",
+    cell_range = "B22:K26",
+    description = "Pumped-hydro storage operating-property assumptions.",
+    source_family = :storage,
+    consumer = :ess_tables,
+)
+const ISP2024_BESS_MAX_CAPACITY_SOURCE = _isp2024_xlsx_source(
+    id = :bess_maximum_capacity,
+    worksheet = "Maximum capacity",
+    cell_range = "P8:U62",
+    description = "Maximum capacity assumptions for battery storage projects.",
+    source_family = :storage,
+    consumer = :ess_tables,
+)
+const ISP2024_BESS_SUMMARY_MAPPING_SOURCE = _isp2024_xlsx_source(
+    id = :bess_summary_mapping,
+    worksheet = "Summary Mapping",
+    cell_range = "B314:AB370",
+    description = "Storage-project mapping rows used to construct ESS assets.",
+    source_family = :storage,
+    consumer = :ess_tables,
+)
+const ISP2024_EXISTING_GENERATORS_SOURCE = _isp2024_xlsx_source(
+    id = :existing_generators,
+    worksheet = "Existing Gen Data Summary",
+    cell_range = "B11:K297",
+    description = "Existing generator records used to allocate installed solar and wind capacity.",
+    source_family = :generation,
+    consumer = :renewable_generation_schedules,
+)
+const ISP2024_RENEWABLE_ENERGY_ZONES_SOURCE = _isp2024_xlsx_source(
+    id = :renewable_energy_zones,
+    worksheet = "Renewable Energy Zones",
+    cell_range = "B7:G50",
+    description = "Renewable energy zone identifiers and ISP subregion mappings.",
+    source_family = :renewable_energy_zones,
+    consumer = :renewable_generation_schedules,
+)
+const ISP2024_CONDENSED_CAPACITY_OUTLOOK_SOURCE = _isp2024_xlsx_source(
+    id = :condensed_capacity_outlook,
+    workbook = ISP2024_CONDENSED_CAPACITY_WORKBOOK,
+    worksheet = "CapacityOutlook",
+    cell_range = "A1:G14356",
+    description = "Condensed scenario capacity outlook generated from the AEMO core workbooks.",
+    columns = ColumnSpec[
+        ColumnSpec(name = "Scenario"),
+        ColumnSpec(name = "Subregion"),
+        ColumnSpec(name = "Technology"),
+        ColumnSpec(name = "date"),
+        ColumnSpec(name = "value", data_type = :Real, unit = "MW"),
+    ],
+    source_family = :generation_outlook,
+    consumer = :renewable_generation_schedules,
+)
+const ISP2024_AUXILIARY_REZ_CAPACITY_SOURCE = _isp2024_xlsx_source(
+    id = :auxiliary_rez_generation_capacity,
+    workbook = ISP2024_REZ_CAPACITY_WORKBOOK_PATTERN,
+    worksheet = "REZ Generation Capacity",
+    cell_range = "A1:AG2238",
+    description = "Scenario-specific REZ generation capacities generated from the AEMO core workbooks.",
+    columns = ColumnSpec[
+        ColumnSpec(name = "CDP"),
+        ColumnSpec(name = "REZ"),
+        ColumnSpec(name = "Technology"),
+    ],
+    source_family = :generation_outlook,
+    consumer = :renewable_generation_schedules,
+)
+const ISP2024_VPP_CAPACITY_SOURCE = _isp2024_xlsx_source(
+    id = :vpp_capacity_outlook,
+    workbook = ISP2024_VPP_CAPACITY_WORKBOOK,
+    worksheet = "{scenario}",
+    cell_range = "A1:AG1769",
+    description = "Scenario-specific coordinated CER storage capacity outlook.",
+    source_family = :storage,
+    consumer = :ess_vpps,
+)
+const ISP2024_VPP_ENERGY_SOURCE = _isp2024_xlsx_source(
+    id = :vpp_energy_outlook,
+    workbook = ISP2024_VPP_ENERGY_WORKBOOK,
+    worksheet = "{scenario}",
+    cell_range = "A1:AG1769",
+    description = "Scenario-specific coordinated CER storage energy outlook.",
+    source_family = :storage,
+    consumer = :ess_vpps,
+)
+
+const ISP2024_DISTRIBUTED_PV_TRACE_SOURCE = CsvSourceSpec(
+    id = :distributed_pv_demand_trace,
+    edition = 2024,
+    filename_pattern = "demand_{subregion}_{scenario}/{subregion}_RefYear_{reference_year}_{scenario_code}_POE{poe}_PV_TOT.csv",
+    description = "Distributed-PV traces embedded in the AEMO demand-trace publication.",
+    columns = ISP2024_TRACE_DATE_COLUMNS,
+    keys = ["Year", "Month", "Day"],
+    source_family = :demand_traces,
+    consumer = :gen_pmax_distpv,
+)
+const ISP2024_OPERATIONAL_DEMAND_TRACE_SOURCE = CsvSourceSpec(
+    id = :operational_demand_trace,
+    edition = 2024,
+    filename_pattern = "demand_{subregion}_{scenario}/{subregion}_RefYear_{reference_year}_{scenario_code}_POE{poe}_OPSO_MODELLING_PVLITE.csv",
+    description = "Operational demand traces net of rooftop PV-lite profiles.",
+    columns = ISP2024_TRACE_DATE_COLUMNS,
+    keys = ["Year", "Month", "Day"],
+    source_family = :demand_traces,
+    consumer = :dem_load_sched,
+)
+const ISP2024_EXISTING_SOLAR_TRACE_SOURCE = CsvSourceSpec(
+    id = :existing_solar_trace,
+    edition = 2024,
+    filename_pattern = "solar_{reference_year}/{generator_file}",
+    description = "Existing utility-scale solar trace selected for an existing generator.",
+    columns = ISP2024_TRACE_DATE_COLUMNS,
+    keys = ["Year", "Month", "Day"],
+    source_family = :solar_traces,
+    consumer = :gen_pmax_solar,
+)
+const ISP2024_REZ_SOLAR_TRACE_SOURCE = CsvSourceSpec(
+    id = :rez_solar_trace,
+    edition = 2024,
+    filename_pattern = "solar_{reference_year}/{rez_trace_file}",
+    description = "Renewable-energy-zone solar trace used for future capacity profiles.",
+    columns = ISP2024_TRACE_DATE_COLUMNS,
+    keys = ["Year", "Month", "Day"],
+    source_family = :solar_traces,
+    consumer = :gen_pmax_solar,
+)
+const ISP2024_EXISTING_WIND_TRACE_SOURCE = CsvSourceSpec(
+    id = :existing_wind_trace,
+    edition = 2024,
+    filename_pattern = "wind_{reference_year}/{generator_file}",
+    description = "Existing wind trace selected for an existing generator.",
+    columns = ISP2024_TRACE_DATE_COLUMNS,
+    keys = ["Year", "Month", "Day"],
+    source_family = :wind_traces,
+    consumer = :gen_pmax_wind,
+)
+const ISP2024_REZ_WIND_TRACE_SOURCE = CsvSourceSpec(
+    id = :rez_wind_trace,
+    edition = 2024,
+    filename_pattern = "wind_{reference_year}/{rez_trace_file}",
+    description = "Renewable-energy-zone wind trace used for future capacity profiles.",
+    columns = ISP2024_TRACE_DATE_COLUMNS,
+    keys = ["Year", "Month", "Day"],
+    source_family = :wind_traces,
+    consumer = :gen_pmax_wind,
+)
+const ISP2024_HYDRO_NATURAL_INFLOW_TRACE_SOURCE = CsvSourceSpec(
+    id = :hydro_natural_inflow_trace,
+    edition = 2024,
+    filename_pattern = "2024 ISP {scenario}/Traces/hydro/{file_name}_{hydro_scenario}.csv",
+    description = "Daily natural hydro inflow trace for a mapped hydro generator group.",
+    columns = ColumnSpec[
+        ISP2024_TRACE_DATE_COLUMNS...,
+        ColumnSpec(name = "Inflows", data_type = :Real),
+    ],
+    keys = ["Year", "Month", "Day"],
+    source_family = :hydro,
+    consumer = :gen_inflow_sched,
+)
+const ISP2024_HYDRO_ANNUAL_ENERGY_TRACE_SOURCE = CsvSourceSpec(
+    id = :hydro_annual_energy_limit_trace,
+    edition = 2024,
+    filename_pattern = "2024 ISP {scenario}/Traces/hydro/{file_name}_{hydro_scenario}.csv",
+    description = "Annual hydro energy-limit trace with one column per mapped constraint.",
+    columns = ColumnSpec[
+        ColumnSpec(name = "Year", data_type = :Integer),
+    ],
+    keys = ["Year"],
+    source_family = :hydro,
+    consumer = :gen_inflow_sched,
+)
+
+const ISP2024_DSP_SOURCE_LAYOUTS = [
+    (scenario = "Progressive Change", region = "QLD", season = "SUMMER", cell_range = "B128:AG133"),
+    (scenario = "Progressive Change", region = "QLD", season = "WINTER", cell_range = "B137:AG142"),
+    (scenario = "Progressive Change", region = "NSW", season = "SUMMER", cell_range = "B108:AG113"),
+    (scenario = "Progressive Change", region = "NSW", season = "WINTER", cell_range = "B118:AG123"),
+    (scenario = "Progressive Change", region = "SA", season = "SUMMER", cell_range = "B147:AG152"),
+    (scenario = "Progressive Change", region = "SA", season = "WINTER", cell_range = "B156:AG161"),
+    (scenario = "Progressive Change", region = "TAS", season = "SUMMER", cell_range = "B166:AG171"),
+    (scenario = "Progressive Change", region = "TAS", season = "WINTER", cell_range = "B175:AG180"),
+    (scenario = "Progressive Change", region = "VIC", season = "SUMMER", cell_range = "B185:AG190"),
+    (scenario = "Progressive Change", region = "VIC", season = "WINTER", cell_range = "B194:AG199"),
+    (scenario = "Step Change", region = "QLD", season = "SUMMER", cell_range = "B226:AG231"),
+    (scenario = "Step Change", region = "QLD", season = "WINTER", cell_range = "B235:AG240"),
+    (scenario = "Step Change", region = "NSW", season = "SUMMER", cell_range = "B206:AG211"),
+    (scenario = "Step Change", region = "NSW", season = "WINTER", cell_range = "B216:AG221"),
+    (scenario = "Step Change", region = "SA", season = "SUMMER", cell_range = "B245:AG250"),
+    (scenario = "Step Change", region = "SA", season = "WINTER", cell_range = "B254:AG259"),
+    (scenario = "Step Change", region = "TAS", season = "SUMMER", cell_range = "B264:AG269"),
+    (scenario = "Step Change", region = "TAS", season = "WINTER", cell_range = "B273:AG278"),
+    (scenario = "Step Change", region = "VIC", season = "SUMMER", cell_range = "B283:AG288"),
+    (scenario = "Step Change", region = "VIC", season = "WINTER", cell_range = "B292:AG297"),
+    (scenario = "Green Energy Exports", region = "QLD", season = "SUMMER", cell_range = "B30:AG35"),
+    (scenario = "Green Energy Exports", region = "QLD", season = "WINTER", cell_range = "B39:AG44"),
+    (scenario = "Green Energy Exports", region = "NSW", season = "SUMMER", cell_range = "B10:AG15"),
+    (scenario = "Green Energy Exports", region = "NSW", season = "WINTER", cell_range = "B20:AG25"),
+    (scenario = "Green Energy Exports", region = "SA", season = "SUMMER", cell_range = "B49:AG54"),
+    (scenario = "Green Energy Exports", region = "SA", season = "WINTER", cell_range = "B58:AG63"),
+    (scenario = "Green Energy Exports", region = "TAS", season = "SUMMER", cell_range = "B68:AG73"),
+    (scenario = "Green Energy Exports", region = "TAS", season = "WINTER", cell_range = "B77:AG82"),
+    (scenario = "Green Energy Exports", region = "VIC", season = "SUMMER", cell_range = "B87:AG92"),
+    (scenario = "Green Energy Exports", region = "VIC", season = "WINTER", cell_range = "B96:AG101"),
+]
+
+const ISP2024_DSP_SOURCE_SPECS = XlsxSourceSpec[
+    _isp2024_xlsx_source(
+        id = Symbol(
+            "dsp_",
+            _source_spec_slug(layout.scenario),
+            "_",
+            lowercase(layout.region),
+            "_",
+            lowercase(layout.season),
+        ),
+        worksheet = "DSP",
+        cell_range = layout.cell_range,
+        description = "$(layout.scenario) $(layout.region) $(lowercase(layout.season)) demand-side participation profile.",
+        source_family = :demand_side_participation,
+        consumer = :der_pred_sched,
+    )
+    for layout in ISP2024_DSP_SOURCE_LAYOUTS
+]
+
+const ISP2024_DSP_SOURCE_SPEC_BY_KEY = Dict(
+    (layout.scenario, layout.region, layout.season) => spec
+    for (layout, spec) in zip(ISP2024_DSP_SOURCE_LAYOUTS, ISP2024_DSP_SOURCE_SPECS)
+)
+
+const ISP2024_PARSER_SOURCE_SPECS = SourceSpec[
+    ISP2024_NETWORK_CAPABILITY_SOURCE,
+    ISP2024_TRANSMISSION_RELIABILITY_SOURCE,
+    ISP2024_FLOW_PATH_AUGMENTATION_SOURCE,
+    ISP2024_GENERATOR_MAPPING_NAMES_SOURCE,
+    ISP2024_GENERATOR_MAPPING_MLF_SOURCE,
+    ISP2024_EXISTING_GENERATOR_MAX_CAPACITY_SOURCE,
+    ISP2024_COMMITTED_GENERATOR_MAX_CAPACITY_SOURCE,
+    ISP2024_ANTICIPATED_GENERATOR_MAX_CAPACITY_SOURCE,
+    ISP2024_GENERATOR_SUMMARY_MAPPING_SOURCE,
+    ISP2024_COAL_MINIMUM_STABLE_GENERATION_SOURCE,
+    ISP2024_GPG_MINIMUM_STABLE_GENERATION_SOURCE,
+    ISP2024_GENERATOR_MIN_UP_DOWN_SOURCE,
+    ISP2024_LEGACY_GENERATOR_MIN_UP_SOURCE,
+    ISP2024_GENERATOR_RAMP_RATES_SOURCE,
+    ISP2024_GENERATOR_RETIREMENTS_SOURCE,
+    ISP2024_EXISTING_GENERATOR_RELIABILITY_SOURCE,
+    ISP2024_NEW_GENERATOR_RELIABILITY_SOURCE,
+    ISP2024_EXISTING_GENERATOR_SUMMARY_SOURCE,
+    ISP2024_ADDITIONAL_GENERATOR_SUMMARY_SOURCE,
+    ISP2024_GENERATOR_EMISSIONS_SOURCE,
+    ISP2024_BESS_PROPERTIES_SOURCE,
+    ISP2024_PUMPED_STORAGE_PROPERTIES_SOURCE,
+    ISP2024_BESS_MAX_CAPACITY_SOURCE,
+    ISP2024_BESS_SUMMARY_MAPPING_SOURCE,
+    ISP2024_EXISTING_GENERATORS_SOURCE,
+    ISP2024_RENEWABLE_ENERGY_ZONES_SOURCE,
+    ISP2024_CONDENSED_CAPACITY_OUTLOOK_SOURCE,
+    ISP2024_AUXILIARY_REZ_CAPACITY_SOURCE,
+    ISP2024_VPP_CAPACITY_SOURCE,
+    ISP2024_VPP_ENERGY_SOURCE,
+    ISP2024_DISTRIBUTED_PV_TRACE_SOURCE,
+    ISP2024_OPERATIONAL_DEMAND_TRACE_SOURCE,
+    ISP2024_EXISTING_SOLAR_TRACE_SOURCE,
+    ISP2024_REZ_SOLAR_TRACE_SOURCE,
+    ISP2024_EXISTING_WIND_TRACE_SOURCE,
+    ISP2024_REZ_WIND_TRACE_SOURCE,
+    ISP2024_HYDRO_NATURAL_INFLOW_TRACE_SOURCE,
+    ISP2024_HYDRO_ANNUAL_ENERGY_TRACE_SOURCE,
+]
+
+register_source_specs!(ISP2024_PARSER_SOURCE_SPECS...)
+register_source_specs!(ISP2024_DSP_SOURCE_SPECS...)
+
 """
     bus_table(ts)
 
@@ -59,8 +547,8 @@ generation routines.
 function line_table(ts::PISPtimeStatic, tv::PISPtimeVarying, ispdata24::String)
     bust = ts.bus
     # Read ISP Workbook with line capacities
-    DATALINES   = PISP.read_xlsx_with_header(ispdata24, "Network Capability", "B6:H21")
-    RELIALINES  = PISP.read_xlsx_with_header(ispdata24, "Transmission Reliability", "B7:G11")
+    DATALINES   = PISP.read_xlsx_with_header(ispdata24, ISP2024_NETWORK_CAPABILITY_SOURCE)
+    RELIALINES  = PISP.read_xlsx_with_header(ispdata24, ISP2024_TRANSMISSION_RELIABILITY_SOURCE)
     Results = DataFrame(name = String[], busA = String[], busB = String[], idbusA = Int64[], idbusB = Int64[], fwd_peak = Float64[], fwd_summer = Float64[], fwd_winter = Float64[], rev_peak = Float64[], rev_summer = Float64[], rev_winter = Float64[])
     # Link names
     NEMTX = ["CQ->NQ", "CQ->GG", "SQ->CQ", "QNI North", "Terranora", "QNI South","CNSW->SNW North","CNSW->SNW South", "VNI North","VNI South","Heywood","SESA->CSA","Murraylink", "Basslink"]
@@ -251,7 +739,7 @@ ratings, and activation flags.
 function line_invoptions(ts::PISPtimeStatic, ispdata24::String)
     bust = ts.bus
     maxidlin = isempty(ts.line) ? 0 : maximum(ts.line.id_lin)
-    DATALININV = PISP.read_xlsx_with_header(ispdata24, "Flow Path Augmentation options", "B11:N94")
+    DATALININV = PISP.read_xlsx_with_header(ispdata24, ISP2024_FLOW_PATH_AUGMENTATION_SOURCE)
     skip = ["Option Name",""]
     df = DataFrame(Option = String[], Direction = String[], Forward = Float64[], Reverse = Float64[], Cost = Float64[], LeadYears = Float64[])
 
@@ -330,21 +818,21 @@ function generator_table(ts::PISPtimeStatic, ispdata19::String, ispdata24::Strin
                 "january" => 1, "february" => 2, "march" => 3, "april" => 4, "may" => 5, "june" => 6, "july" => 7, "august" => 8, "september" => 9, "october" => 10, "november" => 11, "december" => 12)
 
     str2date(date) = date isa Number ? Dates.DateTime(1899, 12, 30) + Dates.Day(date) : DateTime(parse(Int64,split(date,' ')[2]),m2n[lowercase(split(date,' ')[1])])
-    MAPPING  = PISP.read_xlsx_with_header(ispdata24, "Summary Mapping", "B6:B680")      # EXISTING GENERATOR
-    MAPPING2 = PISP.read_xlsx_with_header(ispdata24, "Summary Mapping", "AA6:AA680")    # MLF
+    MAPPING  = PISP.read_xlsx_with_header(ispdata24, ISP2024_GENERATOR_MAPPING_NAMES_SOURCE)      # EXISTING GENERATOR
+    MAPPING2 = PISP.read_xlsx_with_header(ispdata24, ISP2024_GENERATOR_MAPPING_MLF_SOURCE)    # MLF
     namedict = PISP.OrderedDict(zip(MAPPING[!,1], MAPPING2[!,1]))
 
     # ====================================== #
     # ==== General list of Power Plants ==== #
     # ====================================== #
-    GENS = PISP.read_xlsx_with_header(ispdata24, "Maximum capacity", "B8:D260")
+    GENS = PISP.read_xlsx_with_header(ispdata24, ISP2024_EXISTING_GENERATOR_MAX_CAPACITY_SOURCE)
     GENS[!, :Generator] = [k == "Bogong / Mackay" ? "Bogong / MacKay" : k for k in GENS[!, :Generator]] # Fix for Bogong / Mackay
     GENS[!, :Generator] = [k == "Lincoln Gap Wind Farm - Stage 2" ? "Lincoln Gap Wind Farm - stage 2" : k for k in GENS[!, :Generator]] # Fix for Bogong / Mackay
 
-    COMGEN_MAXCAP = PISP.read_xlsx_with_header(ispdata24, "Maximum capacity", "F8:I35")
-    ADVGEN_MAXCAP = PISP.read_xlsx_with_header(ispdata24, "Maximum capacity", "K8:N24")
+    COMGEN_MAXCAP = PISP.read_xlsx_with_header(ispdata24, ISP2024_COMMITTED_GENERATOR_MAX_CAPACITY_SOURCE)
+    ADVGEN_MAXCAP = PISP.read_xlsx_with_header(ispdata24, ISP2024_ANTICIPATED_GENERATOR_MAX_CAPACITY_SOURCE)
 
-    MAPPING3 = PISP.read_xlsx_with_header(ispdata24, "Summary Mapping", "B4:I680")
+    MAPPING3 = PISP.read_xlsx_with_header(ispdata24, ISP2024_GENERATOR_SUMMARY_MAPPING_SOURCE)
     MAPPING3 = MAPPING3[completecases(MAPPING3),:]                              # SELECT ONLY ROWS OF MAPPING3 WITHOUT MISSING VALUES
     rename!(MAPPING3, 1 => :Generator)                                          # Rename first column to "Generator" 
 
@@ -377,17 +865,17 @@ function generator_table(ts::PISPtimeStatic, ispdata19::String, ispdata24::Strin
     # Units with unit commitment and ramping #
     # ====================================== #
     # Generation limits and stable levels for coal and gas generators
-    DATA_COALMSG = PISP.read_xlsx_with_header(ispdata24, "Generation limits", "B8:D52")
-    DATA_GPGMSG = PISP.read_xlsx_with_header(ispdata24, "GPG Min Stable Level", "B9:E34")
+    DATA_COALMSG = PISP.read_xlsx_with_header(ispdata24, ISP2024_COAL_MINIMUM_STABLE_GENERATION_SOURCE)
+    DATA_GPGMSG = PISP.read_xlsx_with_header(ispdata24, ISP2024_GPG_MINIMUM_STABLE_GENERATION_SOURCE)
     select!(DATA_GPGMSG, Not(Symbol("Technology Type")))
 
     # Minimum up times for different units
-    DATA_MINUP_UNITS = PISP.read_xlsx_with_header(ispdata24, "Min Up&Down Times", "B8:E25")
-    DATA_MINUP_UNITS19 = PISP.read_xlsx_with_header(ispdata19, "Generation limits", "O9:Q69") # Min UP and DW - GAS+COAL UNITS (2019)
+    DATA_MINUP_UNITS = PISP.read_xlsx_with_header(ispdata24, ISP2024_GENERATOR_MIN_UP_DOWN_SOURCE)
+    DATA_MINUP_UNITS19 = PISP.read_xlsx_with_header(ispdata19, ISP2024_LEGACY_GENERATOR_MIN_UP_SOURCE) # Min UP and DW - GAS+COAL UNITS (2019)
     select!(DATA_MINUP_UNITS, Not(Symbol("Technology Type")))
     XLSX.writetable(".tmp/DATA_MINUP_UNITS19.xlsx", Tables.columntable(DATA_MINUP_UNITS19); sheetname="Generators19", overwrite=true)
     # Ramp rates for different units
-    UC = PISP.read_xlsx_with_header(ispdata24, "Max Ramp Rates", "B8:F72")
+    UC = PISP.read_xlsx_with_header(ispdata24, ISP2024_GENERATOR_RAMP_RATES_SOURCE)
     select!(UC, Not(Symbol("Technology Type")))
     XLSX.writetable(".tmp/UC.xlsx", Tables.columntable(UC); sheetname="UC", overwrite=true)
 
@@ -457,7 +945,7 @@ function generator_table(ts::PISPtimeStatic, ispdata19::String, ispdata24::Strin
     # ====================================== #
     # ============= RETIREMENTS ============ #
     # ====================================== #
-    UNITS = PISP.read_xlsx_with_header(ispdata24, "Retirement", "B9:D460")
+    UNITS = PISP.read_xlsx_with_header(ispdata24, ISP2024_GENERATOR_RETIREMENTS_SOURCE)
     rename!(UNITS, 1 => "Generator")
     UNITS[!,:RETIRE] = DateTime.(PISP.parseif(UNITS[:,3]))
 
@@ -475,15 +963,15 @@ function generator_table(ts::PISPtimeStatic, ispdata19::String, ispdata24::Strin
     # ====================================== #
     # ============= RELIABILITY ============ #
     # ====================================== #
-    RELIA = PISP.read_xlsx_with_header(ispdata24, "Generator Reliability Settings", "B20:G28")
-    RELIANEW = PISP.read_xlsx_with_header(ispdata24, "Generator Reliability Settings", "I20:N40")
+    RELIA = PISP.read_xlsx_with_header(ispdata24, ISP2024_EXISTING_GENERATOR_RELIABILITY_SOURCE)
+    RELIANEW = PISP.read_xlsx_with_header(ispdata24, ISP2024_NEW_GENERATOR_RELIABILITY_SOURCE)
 
 
     # ====================================== #
     # ========= GENERATION SUMMARY ========= #
     # ====================================== #
-    GENSUM     = PISP.read_xlsx_with_header(ispdata24, "Existing Gen Data Summary", "B10:U319")
-    GENSUM_ADD = PISP.read_xlsx_with_header(ispdata24, "Existing Gen Data Summary", "B382:U397")
+    GENSUM     = PISP.read_xlsx_with_header(ispdata24, ISP2024_EXISTING_GENERATOR_SUMMARY_SOURCE)
+    GENSUM_ADD = PISP.read_xlsx_with_header(ispdata24, ISP2024_ADDITIONAL_GENERATOR_SUMMARY_SOURCE)
     GENSUM     = vcat(GENSUM, GENSUM_ADD)
     GENSUM     = GENSUM[3:end,:]
     flagrow    = [!all(ismissing.(Matrix(GENSUM[k:k,2:end]))) for k in 1:nrow(GENSUM)]
@@ -630,7 +1118,7 @@ function generator_table(ts::PISPtimeStatic, ispdata19::String, ispdata24::Strin
     # ====================================== #
     # ============ EMMISSIONS ============== #
     # ====================================== #
-    EMI = PISP.read_xlsx_with_header(ispdata24, "Emissions intensity", "B7:D73")
+    EMI = PISP.read_xlsx_with_header(ispdata24, ISP2024_GENERATOR_EMISSIONS_SOURCE)
     select!(EMI, Not(2))
     rename!(EMI, 2 => "Emissions")
     EMI[!,:Generator] = strip.(EMI[!,:Generator])
@@ -933,11 +1421,11 @@ loss factors.
 function ess_tables(ts::PISPtimeStatic, tv::PISPtimeVarying, PSESS::DataFrame, ispdata24::String)
     bust = ts.bus
 
-    BESS_PROP   = PISP.read_xlsx_with_header(ispdata24, "Storage properties", "B4:H13")
-    PS_PROP     = PISP.read_xlsx_with_header(ispdata24, "Storage properties", "B22:K26")
-    BESS_CAP    = PISP.read_xlsx_with_header(ispdata24, "Maximum capacity", "P8:U62")
-    BESS_SUM    = PISP.read_xlsx_with_header(ispdata24, "Summary Mapping", "B314:AB370")
-    RELIANEW    = PISP.read_xlsx_with_header(ispdata24, "Generator Reliability Settings", "I20:N40")
+    BESS_PROP   = PISP.read_xlsx_with_header(ispdata24, ISP2024_BESS_PROPERTIES_SOURCE)
+    PS_PROP     = PISP.read_xlsx_with_header(ispdata24, ISP2024_PUMPED_STORAGE_PROPERTIES_SOURCE)
+    BESS_CAP    = PISP.read_xlsx_with_header(ispdata24, ISP2024_BESS_MAX_CAPACITY_SOURCE)
+    BESS_SUM    = PISP.read_xlsx_with_header(ispdata24, ISP2024_BESS_SUMMARY_MAPPING_SOURCE)
+    RELIANEW    = PISP.read_xlsx_with_header(ispdata24, ISP2024_NEW_GENERATOR_RELIABILITY_SOURCE)
 
     BESS_SUM = BESS_SUM[3:end,:]
     BESS_SUM[!,:cheff] = [replace(BESS_SUM[i,Symbol("VOM (\$/MWh sent-out)")], "All " => "") for i in 1:nrow(BESS_SUM)]
@@ -1089,7 +1577,16 @@ function gen_pmax_distpv(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVar
             scid = probs[p,:scenario][1]
             sc = PISP.ID2SCE[scid]
 
-            df = CSV.File(string(profilespath,"demand_$(st)_$(sc)/",st,"_RefYear_$(refyear)_",replace(uppercase(PISP.ID2SCE2[scid]), " " => "_"),"_POE$(poe)_PV_TOT.csv")) |> DataFrame
+            trace_path = PISP.source_path(
+                profilespath,
+                ISP2024_DISTRIBUTED_PV_TRACE_SOURCE;
+                subregion = st,
+                scenario = sc,
+                reference_year = refyear,
+                scenario_code = replace(uppercase(PISP.ID2SCE2[scid]), " " => "_"),
+                poe = poe,
+            )
+            df = PISP.read_csv_source(trace_path, ISP2024_DISTRIBUTED_PV_TRACE_SOURCE)
 
             dstart = probs[p,:dstart]
             dend = probs[p,:dend]
@@ -1157,7 +1654,16 @@ function dem_load_sched(tc::PISPtimeConfig, tv::PISPtimeVarying, profilespath::S
             scid = probs[p,:scenario][1]
             sc = PISP.ID2SCE[scid]
 
-            df = CSV.File(string(profilespath,"demand_$(st)_$(sc)/",st,"_RefYear_$(refyear)_",replace(uppercase(PISP.ID2SCE2[scid]), " " => "_"),"_POE$(poe)_OPSO_MODELLING_PVLITE.csv")) |> DataFrame
+            trace_path = PISP.source_path(
+                profilespath,
+                ISP2024_OPERATIONAL_DEMAND_TRACE_SOURCE;
+                subregion = st,
+                scenario = sc,
+                reference_year = refyear,
+                scenario_code = replace(uppercase(PISP.ID2SCE2[scid]), " " => "_"),
+                poe = poe,
+            )
+            df = PISP.read_csv_source(trace_path, ISP2024_OPERATIONAL_DEMAND_TRACE_SOURCE)
 
             dstart = probs[p,:dstart]
             dend   = probs[p,:dend]
@@ -1199,11 +1705,11 @@ function gen_pmax_solar(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVary
     pmaxid = isempty(tv.gen_pmax.id) ? 0 : maximum(tv.gen_pmax.id);
 
     tch = "Solar"
-    EXIST_TECH = PISP.read_xlsx_with_header(ispdata24, "Existing Gen Data Summary", "B11:K297")
+    EXIST_TECH = PISP.read_xlsx_with_header(ispdata24, ISP2024_EXISTING_GENERATORS_SOURCE)
     EXIST_SOLAR = EXIST_TECH[occursin.(tch[2:end], coalesce.(EXIST_TECH[!,2],"")),:]
     # @warn("Anticipated solar PV projects not considered in the existing data")
 
-    REZ_BUS = PISP.read_xlsx_with_header(ispdata24, "Renewable Energy Zones", "B7:G50")
+    REZ_BUS = PISP.read_xlsx_with_header(ispdata24, ISP2024_RENEWABLE_ENERGY_ZONES_SOURCE)
     # println(REZ_BUS)
 
     genid = Dict()
@@ -1236,11 +1742,14 @@ function gen_pmax_solar(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVary
         dend = probs[p,:dend]
         yr = Dates.year(dstart)
         ms = Dates.month(dstart)
-        # outlookfile = string(outlookdata,"/Auxiliary/2024 ISP - ",sc," - Core_REZCAP.xlsx")
-        outlookfile = normpath(outlookdata, "..", "Auxiliary", "2024 ISP - $(sc) - Core_REZCAP.xlsx")
+        outlookfile = PISP.source_path(
+            normpath(outlookdata, ".."),
+            ISP2024_AUXILIARY_REZ_CAPACITY_SOURCE;
+            scenario = sc,
+        )
 
-        TECH_CAP = PISP.read_xlsx_with_header(outlookAEMO, "CapacityOutlook", "A1:G14356")
-        SOLAR_CAP = PISP.read_xlsx_with_header(outlookfile, "REZ Generation Capacity", "A1:AG2238")
+        TECH_CAP = PISP.read_xlsx_with_header(outlookAEMO, ISP2024_CONDENSED_CAPACITY_OUTLOOK_SOURCE)
+        SOLAR_CAP = PISP.read_xlsx_with_header(outlookfile, ISP2024_AUXILIARY_REZ_CAPACITY_SOURCE)
         # println(SOLAR_CAP)
         # print first rows of SOLAR_CAP
         # println(first(SOLAR_CAP,5))
@@ -1287,7 +1796,13 @@ function gen_pmax_solar(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVary
                         end
                     end
 
-                    df = CSV.File(string(foldertech,file)) |> DataFrame
+                    trace_path = PISP.source_path(
+                        profilespath,
+                        ISP2024_EXISTING_SOLAR_TRACE_SOURCE;
+                        reference_year = refyear,
+                        generator_file = file,
+                    )
+                    df = PISP.read_csv_source(trace_path, ISP2024_EXISTING_SOLAR_TRACE_SOURCE)
 
                     df2 = select_trace_date_window(df, dstart, dend)
                     dataexi = dataexi .+ vec(permutedims(Tables.matrix(df2[:,4:end]))) * EXIST_SOLAR[r,10]
@@ -1311,7 +1826,13 @@ function gen_pmax_solar(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVary
                     for f in filter(f -> !startswith(f, "._"), readdir(foldertech))
                         sub = split(f,['_','.'])
                         if "REZ" in sub && "SAT" in sub && sub[2] in REZs
-                            df = CSV.File(string(foldertech,f)) |> DataFrame
+                            trace_path = PISP.source_path(
+                                profilespath,
+                                ISP2024_REZ_SOLAR_TRACE_SOURCE;
+                                reference_year = refyear,
+                                rez_trace_file = f,
+                            )
+                            df = PISP.read_csv_source(trace_path, ISP2024_REZ_SOLAR_TRACE_SOURCE)
                             df2 = select_trace_date_window(df, dstart, dend)
                             datanew = datanew .+ vec(permutedims(Tables.matrix(df2[:,4:end])))
                             naux += 1
@@ -1380,9 +1901,9 @@ function gen_pmax_wind(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVaryi
     pmaxid = isempty(tv.gen_pmax.id) ? 0 : maximum(tv.gen_pmax.id);
 
     tch = "Wind"
-    EXIST_TECH = PISP.read_xlsx_with_header(ispdata24, "Existing Gen Data Summary", "B11:K297")
+    EXIST_TECH = PISP.read_xlsx_with_header(ispdata24, ISP2024_EXISTING_GENERATORS_SOURCE)
     EXIST_WIND = EXIST_TECH[occursin.(tch[2:end], coalesce.(EXIST_TECH[!,2],"")),:]
-    REZ_BUS = PISP.read_xlsx_with_header(ispdata24, "Renewable Energy Zones", "B7:G50")
+    REZ_BUS = PISP.read_xlsx_with_header(ispdata24, ISP2024_RENEWABLE_ENERGY_ZONES_SOURCE)
 
     genid = Dict()
     for st in setdiff(keys(PISP.NEMBUSNAME),["GG"]) ## Buses with no large-scale solar projects or REZ are not considered
@@ -1419,12 +1940,15 @@ function gen_pmax_wind(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVaryi
         dend = probs[p,:dend]
         yr = Dates.year(dstart)
         ms = Dates.month(dstart)
-        # outlookfile = string(outlookdata,"/Auxiliary/2024 ISP - ",sc," - Core_REZCAP.xlsx")
         # normpath outlook data going one level above
-        outlookfile = normpath(outlookdata, "..", "Auxiliary", "2024 ISP - $(sc) - Core_REZCAP.xlsx")
+        outlookfile = PISP.source_path(
+            normpath(outlookdata, ".."),
+            ISP2024_AUXILIARY_REZ_CAPACITY_SOURCE;
+            scenario = sc,
+        )
 
-        TECH_CAP = PISP.read_xlsx_with_header(outlookAEMO, "CapacityOutlook", "A1:G14356")
-        WIND_CAP = PISP.read_xlsx_with_header(outlookfile, "REZ Generation Capacity", "A1:AG2238")
+        TECH_CAP = PISP.read_xlsx_with_header(outlookAEMO, ISP2024_CONDENSED_CAPACITY_OUTLOOK_SOURCE)
+        WIND_CAP = PISP.read_xlsx_with_header(outlookfile, ISP2024_AUXILIARY_REZ_CAPACITY_SOURCE)
         WIND_CAP = dropmissing(WIND_CAP,:CDP)
         
         y = ms < 7 ? yr - 1 : yr
@@ -1470,7 +1994,13 @@ function gen_pmax_wind(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVaryi
                     end
                     # println(" $(k) ======>", file)
 
-                    df = CSV.File(string(foldertech,file)) |> DataFrame
+                    trace_path = PISP.source_path(
+                        profilespath,
+                        ISP2024_EXISTING_WIND_TRACE_SOURCE;
+                        reference_year = refyear,
+                        generator_file = file,
+                    )
+                    df = PISP.read_csv_source(trace_path, ISP2024_EXISTING_WIND_TRACE_SOURCE)
 
                     df2 = select_trace_date_window(df, dstart, dend)
                     dataexi = dataexi .+ vec(permutedims(Tables.matrix(df2[:,4:end]))) * EXIST_WIND[r,7]
@@ -1494,7 +2024,13 @@ function gen_pmax_wind(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVaryi
                 for f in filter(f -> !startswith(f, "._"), readdir(foldertech))
                     sub = split(f,['_','.'])
                     if sub[1] in REZs && "WH" in sub#f[1] == st[1]
-                        df = CSV.File(string(foldertech,f)) |> DataFrame
+                        trace_path = PISP.source_path(
+                            profilespath,
+                            ISP2024_REZ_WIND_TRACE_SOURCE;
+                            reference_year = refyear,
+                            rez_trace_file = f,
+                        )
+                        df = PISP.read_csv_source(trace_path, ISP2024_REZ_WIND_TRACE_SOURCE)
                         df2 = select_trace_date_window(df, dstart, dend)
                         datanew = datanew .+ vec(permutedims(Tables.matrix(df2[:,4:end])))
                         naux += 1
@@ -1569,12 +2105,12 @@ function ess_vpps(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVarying, v
 
     sc = collect(keys(PISP.SCE))[2]
     # CER STORAGE CAPACITY
-    VPPCAP = PISP.read_xlsx_with_header(vpp_cap, "$(sc)", "A1:AG1769")
+    VPPCAP = PISP.read_xlsx_with_header(vpp_cap, ISP2024_VPP_CAPACITY_SOURCE; worksheet = string(sc))
     VPPCAP = VPPCAP[(VPPCAP[!,1] .== "CDP14") .& (VPPCAP[!,Symbol("storage category")] .== "Coordinated CER storage"),:]
     rename!(VPPCAP, Dict(:Subregion => :bus))
 
     #CER STORAGE ENERGY
-    VPPENE = PISP.read_xlsx_with_header(vpp_ene, "$(sc)", "A1:AG1769")
+    VPPENE = PISP.read_xlsx_with_header(vpp_ene, ISP2024_VPP_ENERGY_SOURCE; worksheet = string(sc))
     VPPENE = VPPENE[(VPPENE[!,1] .== "CDP14") .& (VPPENE[!,Symbol("Technology")] .== "Coordinated CER storage"),:]
     rename!(VPPENE, Dict(:Subregion => :bus))
 
@@ -1602,10 +2138,8 @@ function ess_vpps(tc::PISPtimeConfig, ts::PISPtimeStatic, tv::PISPtimeVarying, v
         me = Dates.month(dend)
 
         yr = ms < 7 ? yr - 1 : yr
-        # VPPCAP = PISP.read_xlsx_with_header(vpp_cap, "$(sc)", "A1:AE2080")
-        # VPPENE = PISP.read_xlsx_with_header(vpp_ene, "$(sc)", "A1:AE2080")
-        VPPCAP = PISP.read_xlsx_with_header(vpp_cap, "$(sc)", "A1:AG1769")
-        VPPENE = PISP.read_xlsx_with_header(vpp_ene, "$(sc)", "A1:AG1769")
+        VPPCAP = PISP.read_xlsx_with_header(vpp_cap, ISP2024_VPP_CAPACITY_SOURCE; worksheet = string(sc))
+        VPPENE = PISP.read_xlsx_with_header(vpp_ene, ISP2024_VPP_ENERGY_SOURCE; worksheet = string(sc))
         for st in keys(PISP.NEMBUSES)
             # CER STORAGE CAPACITY
             VPPCAP = VPPCAP[(VPPCAP[!,1] .== "CDP14") .& (VPPCAP[!,Symbol("storage category")] .== "Coordinated CER storage"),:]
@@ -1699,40 +2233,23 @@ inserted by `der_tables`.
 - `dsp_data::String`: Path to the DSP workbook or data file.
 """
 function der_pred_sched(ts::PISPtimeStatic, tv::PISPtimeVarying, ispdata24::String)
-    sce_dsp = Dict("Progressive Change"     => Dict("QLD" => Dict("SUMMER"  => "B128:AG133", "WINTER"  =>"B137:AG142"), 
-                                                    "NSW" => Dict("SUMMER"  => "B108:AG113", "WINTER"  =>"B118:AG123"), 
-                                                    "SA"  => Dict("SUMMER"  => "B147:AG152", "WINTER"  => "B156:AG161"),
-                                                    "TAS" => Dict("SUMMER"  => "B166:AG171", "WINTER"  => "B175:AG180"),
-                                                    "VIC" => Dict("SUMMER"  => "B185:AG190", "WINTER"  => "B194:AG199")),
-
-                   "Step Change"            => Dict("QLD" => Dict("SUMMER" => "B226:AG231", "WINTER" => "B235:AG240"), 
-                                                    "NSW" => Dict("SUMMER" => "B206:AG211", "WINTER" => "B216:AG221"), 
-                                                    "SA"  => Dict("SUMMER" => "B245:AG250", "WINTER" => "B254:AG259"),
-                                                    "TAS" => Dict("SUMMER" => "B264:AG269", "WINTER" => "B273:AG278"),
-                                                    "VIC" => Dict("SUMMER" => "B283:AG288", "WINTER" => "B292:AG297")),
-
-                   "Green Energy Exports"   => Dict("QLD" => Dict("SUMMER"  => "B30:AG35", "WINTER" =>"B39:AG44"), 
-                                                    "NSW" => Dict("SUMMER"  => "B10:AG15", "WINTER" => "B20:AG25"), 
-                                                    "SA"  => Dict("SUMMER"  =>"B49:AG54", "WINTER"  =>"B58:AG63"), 
-                                                    "TAS" => Dict("SUMMER"  =>"B68:AG73", "WINTER"  =>"B77:AG82"),
-                                                    "VIC" => Dict("SUMMER"  =>"B87:AG92", "WINTER"  =>"B96:AG101")))
+    dsp_sources = ISP2024_DSP_SOURCE_SPEC_BY_KEY
 
     for scenario in collect(keys(PISP.SCE))
-        sce_map = sce_dsp[scenario]
-        QLD_SUM = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["QLD"]["SUMMER"])
-        QLD_WIN = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["QLD"]["WINTER"])
+        QLD_SUM = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "QLD", "SUMMER")])
+        QLD_WIN = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "QLD", "WINTER")])
 
-        NSW_SUM = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["NSW"]["SUMMER"])
-        NSW_WIN = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["NSW"]["WINTER"])
+        NSW_SUM = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "NSW", "SUMMER")])
+        NSW_WIN = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "NSW", "WINTER")])
 
-        SA_SUM = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["SA"]["SUMMER"])
-        SA_WIN = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["SA"]["WINTER"])
+        SA_SUM = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "SA", "SUMMER")])
+        SA_WIN = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "SA", "WINTER")])
 
-        TAS_SUM = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["TAS"]["SUMMER"])
-        TAS_WIN = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["TAS"]["WINTER"])
+        TAS_SUM = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "TAS", "SUMMER")])
+        TAS_WIN = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "TAS", "WINTER")])
 
-        VIC_SUM = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["VIC"]["SUMMER"])
-        VIC_WIN = PISP.read_xlsx_with_header(ispdata24, "DSP", sce_map["VIC"]["WINTER"])
+        VIC_SUM = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "VIC", "SUMMER")])
+        VIC_WIN = PISP.read_xlsx_with_header(ispdata24, dsp_sources[(scenario, "VIC", "WINTER")])
         # ======================================== #
         # <><><> QLD
         # ++ NQ
@@ -1854,7 +2371,6 @@ function gen_inflow_sched(ts::PISPtimeStatic, tv::PISPtimeVarying, tc::PISPtimeC
 
     # 1 - Hydro Inflows
     for scenario in keys(PISP.SCE)
-        hydro_root    = "$(ispmodel)/2024 ISP $(scenario)/Traces/hydro/"
         sce_label     = PISP.SCE[scenario]      # Scenario number
         hydro_sce     = PISP.HYDROSCE[scenario] # Hydro scenario from PLEXOS model
 
@@ -1867,8 +2383,17 @@ function gen_inflow_sched(ts::PISPtimeStatic, tv::PISPtimeVarying, tc::PISPtimeC
             #print gen_entries id_gen, gen_totcap, partial
             # println(gen_entries[:, [:id_gen, :name, :gen_totcap, :partial]])
 
-            filepath = normpath(hydro_root, file_name * "_" * hydro_sce * ".csv")
-            inflow_data = CSV.read(filepath, DataFrame)
+            filepath = PISP.source_path(
+                ispmodel,
+                ISP2024_HYDRO_NATURAL_INFLOW_TRACE_SOURCE;
+                scenario = scenario,
+                file_name = file_name,
+                hydro_scenario = hydro_sce,
+            )
+            inflow_data = PISP.read_csv_source(
+                filepath,
+                ISP2024_HYDRO_NATURAL_INFLOW_TRACE_SOURCE,
+            )
 
             # Create timestamped DataFrame with daily inflows
             df_timestamped = select(
@@ -1910,7 +2435,6 @@ function gen_inflow_sched(ts::PISPtimeStatic, tv::PISPtimeVarying, tc::PISPtimeC
 
     # 2 - Yearly Energy Limits
     for scenario in keys(PISP.SCE)
-        hydro_root    = "$(ispmodel)/2024 ISP $(scenario)/Traces/hydro/"
         sce_label     = PISP.SCE[scenario]      # Scenario number
         hydro_sce     = PISP.HYDROSCE[scenario] # Hydro scenario from PLEXOS model
 
@@ -1920,8 +2444,17 @@ function gen_inflow_sched(ts::PISPtimeStatic, tv::PISPtimeVarying, tc::PISPtimeC
             gen_entries = hydro_groups[file_name]
             gen_entries[!, :constraint] = [PISP.HYDRO2CNS[row.id_gen] for row in eachrow(gen_entries)] # Map generator to its energy constraint
 
-            filepath    = normpath(hydro_root, file_name * "_" * hydro_sce * ".csv") # Path to energy constraint file
-            inflow_data = CSV.read(filepath, DataFrame) # Read energy constraint data
+            filepath = PISP.source_path(
+                ispmodel,
+                ISP2024_HYDRO_ANNUAL_ENERGY_TRACE_SOURCE;
+                scenario = scenario,
+                file_name = file_name,
+                hydro_scenario = hydro_sce,
+            )
+            inflow_data = PISP.read_csv_source(
+                filepath,
+                ISP2024_HYDRO_ANNUAL_ENERGY_TRACE_SOURCE,
+            )
 
             for constraint in unique(values(PISP.HYDRO2CNS))                        # Loop over unique constraints (many generators may be associated to one constraint)
                 cns_gens = filter(row -> row.constraint == constraint, gen_entries) # Get generators under this constraint
@@ -2157,19 +2690,26 @@ subregional allocation workbook, ensure matching EV DER entries exist in
 function ev_der_sched(tc, ts, tv, iasr2024_path::AbstractString, evworkbook_path::AbstractString)
     bev_phev_profile_weekend_df = ev_build_bev_phev_profile_dataframe(
         evworkbook_path,
-        EV_2024_BEV_PHEV_PROFILE_WEEKEND_SHEET;
+        EV_2024_BEV_PHEV_PROFILE_WEEKEND_SOURCE;
         day_type = "Weekend",
     )
     bev_phev_profile_weekday_df = ev_build_bev_phev_profile_dataframe(
         evworkbook_path,
-        EV_2024_BEV_PHEV_PROFILE_WEEKDAY_SHEET;
+        EV_2024_BEV_PHEV_PROFILE_WEEKDAY_SOURCE;
         day_type = "Weekday",
     )
     profiles = vcat(bev_phev_profile_weekend_df, bev_phev_profile_weekday_df)
 
     vehicle_numbers_wide_dfs = OrderedDict(
-        sheet_name => ev_build_vehicle_numbers_dataframe(evworkbook_path, sheet_name)
-        for sheet_name in ev_get_vehicle_numbers_sheet_names(evworkbook_path)
+        sheet_name => ev_build_vehicle_numbers_dataframe(
+            evworkbook_path,
+            EV_2024_VEHICLE_NUMBERS_SOURCE;
+            worksheet = sheet_name,
+        )
+        for sheet_name in ev_get_vehicle_numbers_sheet_names(
+            evworkbook_path,
+            EV_2024_VEHICLE_NUMBERS_SOURCE,
+        )
     )
     vehicle_numbers_dfs = OrderedDict(
         sheet_name => ev_melt_vehicle_numbers_dataframe(vehicle_numbers_wide_dfs[sheet_name], number_column)
@@ -2186,10 +2726,13 @@ function ev_der_sched(tc, ts, tv, iasr2024_path::AbstractString, evworkbook_path
 
     bev_phev_charge_type_df = ev_build_bev_phev_charge_type_dataframe(
         evworkbook_path,
-        EV_2024_BEV_PHEV_CHARGE_TYPE_SHEET,
+        EV_2024_BEV_PHEV_CHARGE_TYPE_SOURCE,
     )
     subregional_demand_allocation_df = ev_melt_subregional_demand_allocation_dataframe(
-        ev_build_subregional_demand_allocation_dataframe(iasr2024_path),
+        ev_build_subregional_demand_allocation_dataframe(
+            iasr2024_path;
+            source_spec = EV_2024_SUBREGIONAL_DEMAND_ALLOCATION_SOURCE,
+        ),
     )
     ev_assign_subregional_bus_ids!(subregional_demand_allocation_df, ts)
 

--- a/src/scrappers/PISP-scrapper-build.jl
+++ b/src/scrappers/PISP-scrapper-build.jl
@@ -26,6 +26,69 @@ module ISPdatabuilder
 
     const DEFAULT_DATA_ROOT = normpath(@__DIR__, "..", "..", "data-download")
 
+    const ISP2024_CORE_CAPACITY_SOURCE = PISP.XlsxSourceSpec(
+        id = :core_capacity_outlook,
+        edition = 2024,
+        workbook = "Core/{core_workbook}",
+        worksheet = "Capacity",
+        cell_range = "A3:AG5000",
+        description = "Scenario generation-capacity outlook from an AEMO 2024 ISP core workbook.",
+        source_family = :generation_outlook,
+        consumer = :build_capacity_outlook_aux,
+    )
+    const ISP2024_CORE_STORAGE_ENERGY_SOURCE = PISP.XlsxSourceSpec(
+        id = :core_storage_energy_outlook,
+        edition = 2024,
+        workbook = "Core/{core_workbook}",
+        worksheet = "Storage Energy",
+        cell_range = "A3:AG5000",
+        description = "Scenario storage-energy outlook from an AEMO 2024 ISP core workbook.",
+        source_family = :storage_outlook,
+        consumer = :build_storage_outlook_aux,
+    )
+    const ISP2024_CORE_STORAGE_CAPACITY_SOURCE = PISP.XlsxSourceSpec(
+        id = :core_storage_capacity_outlook,
+        edition = 2024,
+        workbook = "Core/{core_workbook}",
+        worksheet = "Storage Capacity",
+        cell_range = "A3:AG5000",
+        description = "Scenario storage-capacity outlook from an AEMO 2024 ISP core workbook.",
+        source_family = :storage_outlook,
+        consumer = :build_storage_outlook_aux,
+    )
+    const ISP2024_CORE_REZ_CAPACITY_SOURCE = PISP.XlsxSourceSpec(
+        id = :core_rez_generation_capacity,
+        edition = 2024,
+        workbook = "Core/{core_workbook}",
+        worksheet = "REZ Generation Capacity",
+        cell_range = "A3:AG5000",
+        description = "Scenario REZ generation-capacity table from an AEMO 2024 ISP core workbook.",
+        source_family = :generation_outlook,
+        consumer = :build_rez_capacity_aux,
+    )
+    const ISP2024_REFERENCE_YEAR_TRACE_SOURCE = PISP.CsvSourceSpec(
+        id = :reference_year_trace,
+        edition = 2024,
+        filename_pattern = "Traces/{technology}_{reference_year}/{trace_file}",
+        description = "Reference-year trace selected while constructing the synthetic RefYear4006 series.",
+        columns = PISP.ColumnSpec[
+            PISP.ColumnSpec(name = "Year", data_type = :Integer),
+            PISP.ColumnSpec(name = "Month", data_type = :Integer),
+            PISP.ColumnSpec(name = "Day", data_type = :Integer),
+        ],
+        keys = ["Year", "Month", "Day"],
+        source_family = :reference_year_traces,
+        consumer = :process_traces,
+    )
+
+    PISP.register_source_specs!(
+        ISP2024_CORE_CAPACITY_SOURCE,
+        ISP2024_CORE_STORAGE_ENERGY_SOURCE,
+        ISP2024_CORE_STORAGE_CAPACITY_SOURCE,
+        ISP2024_CORE_REZ_CAPACITY_SOURCE,
+        ISP2024_REFERENCE_YEAR_TRACE_SOURCE,
+    )
+
     default_data_root() = DEFAULT_DATA_ROOT
     # Ranges to build the 4006 trace 
     # The 4006 trace is based on the ISP model published by AEMO 
@@ -163,7 +226,10 @@ module ISPdatabuilder
                 file_path       = normpath(outlook_core_path, f)
                 parts           = split(f, " - ")
                 scenario_full   = length(parts) >= 2 ? strip(parts[2]) : ""
-                capacity_df     = PISP.read_xlsx_with_header(file_path, "Capacity", "A3:AG5000")
+                capacity_df = PISP.read_xlsx_with_header(
+                    file_path,
+                    ISP2024_CORE_CAPACITY_SOURCE,
+                )
                 insertcols!(capacity_df, 2, :Scenario => fill(scenario_full, nrow(capacity_df)))
                 capacity_df     = filter(row -> any(x -> x isa Number && !ismissing(x), row), capacity_df)
                 push!(all_capacities, capacity_df)
@@ -214,12 +280,18 @@ module ISPdatabuilder
                 parts         = split(f, " - ")
                 scenario_full = length(parts) >= 2 ? strip(parts[2]) : ""
 
-                energy_df = PISP.read_xlsx_with_header(file_path, "Storage Energy", "A3:AG5000")
+                energy_df = PISP.read_xlsx_with_header(
+                    file_path,
+                    ISP2024_CORE_STORAGE_ENERGY_SOURCE,
+                )
                 insertcols!(energy_df, 2, :Scenario => fill(scenario_full, nrow(energy_df)))
                 energy_df = filter(row -> any(x -> x isa Number && !ismissing(x), row), energy_df)
                 push!(storage_energy_dfs, energy_df)
 
-                capacity_df = PISP.read_xlsx_with_header(file_path, "Storage Capacity", "A3:AG5000")
+                capacity_df = PISP.read_xlsx_with_header(
+                    file_path,
+                    ISP2024_CORE_STORAGE_CAPACITY_SOURCE,
+                )
                 insertcols!(capacity_df, 2, :Scenario => fill(scenario_full, nrow(capacity_df)))
                 capacity_df = filter(row -> any(x -> x isa Number && !ismissing(x), row), capacity_df)
                 push!(storage_capacity_dfs, capacity_df)
@@ -263,7 +335,7 @@ module ISPdatabuilder
     end
 
     function read_rez_capacity(path::AbstractString)
-        return PISP.read_xlsx_with_header(path, "REZ Generation Capacity", "A3:AG5000")
+        return PISP.read_xlsx_with_header(path, ISP2024_CORE_REZ_CAPACITY_SOURCE)
     end
 
     function build_rez_capacity_aux(; data_root::AbstractString = DEFAULT_DATA_ROOT)
@@ -288,8 +360,11 @@ module ISPdatabuilder
         return outputs
     end
 
-    function process_traces(path::AbstractString)
-        df = CSV.read(path, DataFrame)
+    function process_traces(
+        path::AbstractString,
+        source_spec::PISP.CsvSourceSpec = ISP2024_REFERENCE_YEAR_TRACE_SOURCE,
+    )
+        df = PISP.read_csv_source(path, source_spec)
         df.date = Date.(df.Year, df.Month, df.Day)
         return df
     end

--- a/src/utils/dataframes/PISPutils-dataframes.jl
+++ b/src/utils/dataframes/PISPutils-dataframes.jl
@@ -54,6 +54,83 @@ function read_xlsx_with_header(filepath::AbstractString,
     return DataFrame(rows, colnames; makeunique=makeunique)
 end
 
+function _resolved_xlsx_location(
+    spec::XlsxSourceSpec;
+    worksheet::AbstractString = spec.worksheet,
+    cell_range = spec.cell_range,
+)
+    resolved_worksheet = String(strip(String(worksheet)))
+    isempty(resolved_worksheet) &&
+        throw(ArgumentError("Resolved worksheet must not be empty for source $(spec.id)."))
+
+    cell_range === nothing &&
+        throw(ArgumentError("Source $(spec.id) does not define a cell range."))
+    resolved_range = String(strip(String(cell_range)))
+    is_valid_excel_range(resolved_range) ||
+        throw(ArgumentError("Invalid Excel range `$(resolved_range)` for source $(spec.id)."))
+
+    return resolved_worksheet, resolved_range
+end
+
+function validate_source_columns(table, spec::SourceSpec)
+    isempty(spec.columns) && return table
+    available = Set(string.(names(table)))
+    missing_columns = [
+        column.name for column in spec.columns
+        if column.required && !(column.name in available)
+    ]
+    isempty(missing_columns) || throw(ArgumentError(
+        "Source $(spec.id) is missing required columns: $(join(missing_columns, ", ")).",
+    ))
+    return table
+end
+
+function read_xlsx_rows(
+    filepath::AbstractString,
+    spec::XlsxSourceSpec;
+    worksheet::AbstractString = spec.worksheet,
+    cell_range = spec.cell_range,
+)
+    resolved_worksheet, resolved_range = _resolved_xlsx_location(
+        spec;
+        worksheet = worksheet,
+        cell_range = cell_range,
+    )
+    return XLSX.readdata(filepath, resolved_worksheet, resolved_range)
+end
+
+function read_xlsx_with_header(
+    filepath::AbstractString,
+    spec::XlsxSourceSpec;
+    worksheet::AbstractString = spec.worksheet,
+    cell_range = spec.cell_range,
+    makeunique::Bool = true,
+    validate_columns::Bool = false,
+)
+    resolved_worksheet, resolved_range = _resolved_xlsx_location(
+        spec;
+        worksheet = worksheet,
+        cell_range = cell_range,
+    )
+    table = read_xlsx_with_header(
+        filepath,
+        resolved_worksheet,
+        resolved_range;
+        makeunique = makeunique,
+    )
+    return validate_columns ? validate_source_columns(table, spec) : table
+end
+
+function read_csv_source(
+    filepath::AbstractString,
+    spec::CsvSourceSpec;
+    validate_columns::Bool = false,
+    kwargs...
+)
+    table = CSV.File(filepath; kwargs...) |> DataFrame
+    return validate_columns ? validate_source_columns(table, spec) : table
+end
+
 """
     schema_to_dataframe(schema::OrderedDict{String,String})
     Convert a schema (SQL-like column definitions) into an empty DataFrame with correct Julia column types.
@@ -77,6 +154,5 @@ function schema_to_dataframe(schema::OrderedDict{String,String})
     end
     return DataFrame(cols, names)
 end
-
 
 

--- a/src/utils/dataframes/PISPutils-df-evs-2024.jl
+++ b/src/utils/dataframes/PISPutils-df-evs-2024.jl
@@ -7,12 +7,71 @@ if !isdefined(@__MODULE__, :NEMAREAS)
     include(joinpath(dirname(dirname(@__DIR__)), "parameters", "general2024ISP.jl"))
 end
 
-if !isdefined(@__MODULE__, :EV_2024_BEV_PHEV_PROFILE_WEEKEND_SHEET)
-    const EV_2024_BEV_PHEV_PROFILE_WEEKEND_SHEET = "BEV_PHEV_Profile_kW (Weekend)"
-    const EV_2024_BEV_PHEV_PROFILE_WEEKDAY_SHEET = "BEV_PHEV_Profile_kW (Weekday)"
-    const EV_2024_BEV_PHEV_CHARGE_TYPE_SHEET = "BEV_PHEV_Charge_Type (%)"
-    const EV_2024_VEHICLE_NUMBERS_SHEET_SUFFIX = "_Numbers"
-    const EV_2024_SUBREGIONAL_DEMAND_ALLOCATION_SHEET = "Sub-regional demand allocation"
+if !isdefined(@__MODULE__, :EV_2024_BEV_PHEV_PROFILE_WEEKEND_SOURCE)
+    const EV_2024_BEV_PHEV_PROFILE_WEEKEND_SOURCE = XlsxSourceSpec(
+        id = :ev_bev_phev_profile_weekend,
+        edition = 2024,
+        workbook = "2023-iasr-ev-workbook.xlsx",
+        worksheet = "BEV_PHEV_Profile_kW (Weekend)",
+        cell_range = "B:AY",
+        description = "Weekend BEV and PHEV charging profiles by state and vehicle type.",
+        source_family = :electric_vehicles,
+        consumer = :ev_der_sched,
+    )
+    const EV_2024_BEV_PHEV_PROFILE_WEEKDAY_SOURCE = XlsxSourceSpec(
+        id = :ev_bev_phev_profile_weekday,
+        edition = 2024,
+        workbook = "2023-iasr-ev-workbook.xlsx",
+        worksheet = "BEV_PHEV_Profile_kW (Weekday)",
+        cell_range = "B:AY",
+        description = "Weekday BEV and PHEV charging profiles by state and vehicle type.",
+        source_family = :electric_vehicles,
+        consumer = :ev_der_sched,
+    )
+    const EV_2024_BEV_PHEV_CHARGE_TYPE_SOURCE = XlsxSourceSpec(
+        id = :ev_bev_phev_charge_type,
+        edition = 2024,
+        workbook = "2023-iasr-ev-workbook.xlsx",
+        worksheet = "BEV_PHEV_Charge_Type (%)",
+        cell_range = "B:BF",
+        description = "BEV and PHEV charging-type shares by state, scenario, category and year.",
+        source_family = :electric_vehicles,
+        consumer = :ev_der_sched,
+    )
+    const EV_2024_VEHICLE_NUMBERS_SOURCE = XlsxSourceSpec(
+        id = :ev_vehicle_numbers,
+        edition = 2024,
+        workbook = "2023-iasr-ev-workbook.xlsx",
+        worksheet = "*_Numbers",
+        cell_range = "B:AZ",
+        description = "Vehicle-number sheets selected by the `_Numbers` worksheet suffix.",
+        source_family = :electric_vehicles,
+        consumer = :ev_der_sched,
+    )
+    const EV_2024_SUBREGIONAL_DEMAND_ALLOCATION_SOURCE = XlsxSourceSpec(
+        id = :ev_subregional_demand_allocation,
+        edition = 2024,
+        workbook = "2024-isp-inputs-and-assumptions-workbook.xlsx",
+        worksheet = "Sub-regional demand allocation",
+        cell_range = "B127:AG182",
+        description = "Subregional EV demand allocations by scenario and financial year.",
+        source_family = :electric_vehicles,
+        consumer = :ev_der_sched,
+    )
+
+    register_source_specs!(
+        EV_2024_BEV_PHEV_PROFILE_WEEKEND_SOURCE,
+        EV_2024_BEV_PHEV_PROFILE_WEEKDAY_SOURCE,
+        EV_2024_BEV_PHEV_CHARGE_TYPE_SOURCE,
+        EV_2024_VEHICLE_NUMBERS_SOURCE,
+        EV_2024_SUBREGIONAL_DEMAND_ALLOCATION_SOURCE,
+    )
+
+    const EV_2024_BEV_PHEV_PROFILE_WEEKEND_SHEET = EV_2024_BEV_PHEV_PROFILE_WEEKEND_SOURCE.worksheet
+    const EV_2024_BEV_PHEV_PROFILE_WEEKDAY_SHEET = EV_2024_BEV_PHEV_PROFILE_WEEKDAY_SOURCE.worksheet
+    const EV_2024_BEV_PHEV_CHARGE_TYPE_SHEET = EV_2024_BEV_PHEV_CHARGE_TYPE_SOURCE.worksheet
+    const EV_2024_VEHICLE_NUMBERS_SHEET_SUFFIX = replace(EV_2024_VEHICLE_NUMBERS_SOURCE.worksheet, "*" => "")
+    const EV_2024_SUBREGIONAL_DEMAND_ALLOCATION_SHEET = EV_2024_SUBREGIONAL_DEMAND_ALLOCATION_SOURCE.worksheet
     const EV_2024_VEHICLE_NUMBER_VALUE_COLUMN_BY_SHEET = OrderedDict(
         "BEV_Numbers" => :number_bev,
         "PHEV_Numbers" => :number_phev,
@@ -47,6 +106,19 @@ end
 function ev_read_non_empty_rows(workbook_path::AbstractString, sheet_name::AbstractString, range_ref::AbstractString)
     raw_sheet = XLSX.readdata(workbook_path, sheet_name, range_ref)
     return [collect(raw_sheet[row_index, :]) for row_index in axes(raw_sheet, 1) if !ev_is_blank_row(raw_sheet[row_index, :])]
+end
+
+function ev_read_non_empty_rows(
+    workbook_path::AbstractString,
+    spec::XlsxSourceSpec;
+    worksheet::AbstractString = spec.worksheet,
+)
+    raw_sheet = read_xlsx_rows(workbook_path, spec; worksheet = worksheet)
+    return [
+        collect(raw_sheet[row_index, :])
+        for row_index in axes(raw_sheet, 1)
+        if !ev_is_blank_row(raw_sheet[row_index, :])
+    ]
 end
 
 function ev_ensure_columns!(columns::Dict{Symbol, Vector}, column_order::Vector{Symbol}, new_columns::Vector{Symbol}, factory::Function)
@@ -161,8 +233,18 @@ function ev_melt_year_columns_dataframe(
     return long_df[:, [id_columns..., :year, value_name]]
 end
 
-function ev_build_bev_phev_profile_dataframe(workbook_path::AbstractString, sheet_name::AbstractString; day_type::AbstractString)
-    non_empty_rows = ev_read_non_empty_rows(workbook_path, sheet_name, "B:AY")
+function ev_build_bev_phev_profile_dataframe(
+    workbook_path::AbstractString,
+    source_spec::XlsxSourceSpec;
+    day_type::AbstractString,
+    worksheet::AbstractString = source_spec.worksheet,
+)
+    sheet_name = String(worksheet)
+    non_empty_rows = ev_read_non_empty_rows(
+        workbook_path,
+        source_spec;
+        worksheet = sheet_name,
+    )
 
     current_state = nothing
     profile_time_indices = Int[]
@@ -208,8 +290,33 @@ function ev_build_bev_phev_profile_dataframe(workbook_path::AbstractString, shee
     return ev_dataframe_from_columns(column_order, columns)
 end
 
-function ev_build_vehicle_numbers_dataframe(workbook_path::AbstractString, sheet_name::AbstractString)
-    non_empty_rows = ev_read_non_empty_rows(workbook_path, sheet_name, "B:AZ")
+function ev_build_bev_phev_profile_dataframe(
+    workbook_path::AbstractString,
+    sheet_name::AbstractString;
+    day_type::AbstractString,
+)
+    source_spec = sheet_name == EV_2024_BEV_PHEV_PROFILE_WEEKEND_SOURCE.worksheet ?
+        EV_2024_BEV_PHEV_PROFILE_WEEKEND_SOURCE :
+        EV_2024_BEV_PHEV_PROFILE_WEEKDAY_SOURCE
+    return ev_build_bev_phev_profile_dataframe(
+        workbook_path,
+        source_spec;
+        day_type = day_type,
+        worksheet = sheet_name,
+    )
+end
+
+function ev_build_vehicle_numbers_dataframe(
+    workbook_path::AbstractString,
+    source_spec::XlsxSourceSpec;
+    worksheet::AbstractString = source_spec.worksheet,
+)
+    sheet_name = String(worksheet)
+    non_empty_rows = ev_read_non_empty_rows(
+        workbook_path,
+        source_spec;
+        worksheet = sheet_name,
+    )
 
     current_scenario = nothing
     current_state = nothing
@@ -268,9 +375,20 @@ function ev_build_vehicle_numbers_dataframe(workbook_path::AbstractString, sheet
     return ev_dataframe_from_columns(column_order, columns)
 end
 
-function ev_get_vehicle_numbers_sheet_names(workbook_path::AbstractString)
+ev_build_vehicle_numbers_dataframe(workbook_path::AbstractString, sheet_name::AbstractString) =
+    ev_build_vehicle_numbers_dataframe(
+        workbook_path,
+        EV_2024_VEHICLE_NUMBERS_SOURCE;
+        worksheet = sheet_name,
+    )
+
+function ev_get_vehicle_numbers_sheet_names(
+    workbook_path::AbstractString,
+    source_spec::XlsxSourceSpec = EV_2024_VEHICLE_NUMBERS_SOURCE,
+)
+    worksheet_suffix = replace(source_spec.worksheet, "*" => "")
     return XLSX.openxlsx(workbook_path) do workbook
-        filter(sheet_name -> endswith(sheet_name, EV_2024_VEHICLE_NUMBERS_SHEET_SUFFIX), XLSX.sheetnames(workbook))
+        filter(sheet_name -> endswith(sheet_name, worksheet_suffix), XLSX.sheetnames(workbook))
     end
 end
 
@@ -278,8 +396,16 @@ function ev_melt_vehicle_numbers_dataframe(df::DataFrame, number_column::Symbol)
     return ev_melt_year_columns_dataframe(df, [:scenario, :state, :vehicle_type, :category], number_column)
 end
 
-function ev_build_bev_phev_charge_type_dataframe(workbook_path::AbstractString, sheet_name::AbstractString)
-    non_empty_rows = ev_read_non_empty_rows(workbook_path, sheet_name, "B:BF")
+function ev_build_bev_phev_charge_type_dataframe(
+    workbook_path::AbstractString,
+    source_spec::XlsxSourceSpec;
+    worksheet::AbstractString = source_spec.worksheet,
+)
+    non_empty_rows = ev_read_non_empty_rows(
+        workbook_path,
+        source_spec;
+        worksheet = worksheet,
+    )
 
     current_state = nothing
     current_scenario = nothing
@@ -343,8 +469,18 @@ function ev_build_bev_phev_charge_type_dataframe(workbook_path::AbstractString, 
     ])
 end
 
-function ev_build_subregional_demand_allocation_dataframe(workbook_path::AbstractString)
-    non_empty_rows = ev_read_non_empty_rows(workbook_path, EV_2024_SUBREGIONAL_DEMAND_ALLOCATION_SHEET, "B127:AG182")
+ev_build_bev_phev_charge_type_dataframe(workbook_path::AbstractString, sheet_name::AbstractString) =
+    ev_build_bev_phev_charge_type_dataframe(
+        workbook_path,
+        EV_2024_BEV_PHEV_CHARGE_TYPE_SOURCE;
+        worksheet = sheet_name,
+    )
+
+function ev_build_subregional_demand_allocation_dataframe(
+    workbook_path::AbstractString;
+    source_spec::XlsxSourceSpec = EV_2024_SUBREGIONAL_DEMAND_ALLOCATION_SOURCE,
+)
+    non_empty_rows = ev_read_non_empty_rows(workbook_path, source_spec)
 
     current_scenario = nothing
     current_state = nothing

--- a/src/utils/dataframes/PISPutils-df-hydro.jl
+++ b/src/utils/dataframes/PISPutils-df-hydro.jl
@@ -1,5 +1,34 @@
 using CSV
 using DataFrames
+
+const ISP2024_HYDRO_SCHEME_INFLOWS_SOURCE = XlsxSourceSpec(
+    id = :hydro_scheme_inflows,
+    edition = 2024,
+    workbook = "2024-isp-inputs-and-assumptions-workbook.xlsx",
+    worksheet = "Hydro Scheme Inflows",
+    cell_range = "B34:N47",
+    description = "Monthly reference-year inflows used to construct the Snowy hydro schedule.",
+    columns = ColumnSpec[
+        ColumnSpec(name = "Reference Year (FYE)", data_type = :Integer),
+        ColumnSpec(name = "Jul", data_type = :Real),
+        ColumnSpec(name = "Aug", data_type = :Real),
+        ColumnSpec(name = "Sep", data_type = :Real),
+        ColumnSpec(name = "Oct", data_type = :Real),
+        ColumnSpec(name = "Nov", data_type = :Real),
+        ColumnSpec(name = "Dec", data_type = :Real),
+        ColumnSpec(name = "Jan", data_type = :Real),
+        ColumnSpec(name = "Feb", data_type = :Real),
+        ColumnSpec(name = "Mar", data_type = :Real),
+        ColumnSpec(name = "Apr", data_type = :Real),
+        ColumnSpec(name = "May", data_type = :Real),
+        ColumnSpec(name = "Jun", data_type = :Real),
+    ],
+    source_family = :hydro,
+    consumer = :build_hourly_snowy,
+)
+
+register_source_specs!(ISP2024_HYDRO_SCHEME_INFLOWS_SOURCE)
+
 function weather_years_df(d::Dict)
     parse_date(x) = x isa Date ? x : Date(x, dateformat"yyyy-mm-dd")
     rows = [(parse_date(s), parse_date(e), string(v)) for ((s,e), v) in d]
@@ -50,8 +79,9 @@ end
 function build_hourly_snowy(
     ispdata24;
     weather_years = PISP.WEATHER_YEARS,
-    sheet_name = "Hydro Scheme Inflows",
-    cell_range = "B34:N47",
+    source_spec::XlsxSourceSpec = ISP2024_HYDRO_SCHEME_INFLOWS_SOURCE,
+    sheet_name = nothing,
+    cell_range = nothing,
 )
     monthly_cols = Symbol.([:Jul, :Aug, :Sep, :Oct, :Nov, :Dec, :Jan, :Feb, :Mar, :Apr, :May, :Jun])
     month_map = Dict(
@@ -61,7 +91,12 @@ function build_hourly_snowy(
 
     weather_df = weather_years_df(weather_years)
 
-    data = PISP.read_xlsx_with_header(ispdata24, sheet_name, cell_range)
+    data = PISP.read_xlsx_with_header(
+        ispdata24,
+        source_spec;
+        worksheet = something(sheet_name, source_spec.worksheet),
+        cell_range = something(cell_range, source_spec.cell_range),
+    )
     rename!(data, Symbol("Reference Year (FYE)") => :ref_year)
 
     monthly_lookup = select(data, :ref_year => ByRow(string) => :label, monthly_cols...)

--- a/src/utils/general/PISPutils-general.jl
+++ b/src/utils/general/PISPutils-general.jl
@@ -11,16 +11,17 @@ auxiliary outlook files required by the build pipeline.
   the downloaded ISP data structure. Paths are combined using `normpath`.
 """
 function default_data_paths(;filepath=@__DIR__)
+    spec(id) = source_spec(id, 2024)
     return (
-        ispdata19          = normpath(filepath, "2019-input-and-assumptions-workbook-v1-3-dec-19.xlsx"),
-        ispdata24          = normpath(filepath, "2024-isp-inputs-and-assumptions-workbook.xlsx"),
-        iasr23_ev_workbook = normpath(filepath, "2023-iasr-ev-workbook.xlsx"),
+        ispdata19          = source_path(filepath, spec(:legacy_generator_minimum_up_time)),
+        ispdata24          = source_path(filepath, spec(:network_capability)),
+        iasr23_ev_workbook = source_path(filepath, spec(:ev_bev_phev_profile_weekend)),
         ispmodel           = normpath(filepath, "2024 ISP Model"),
         profiledata        = normpath(filepath, "Traces/"),
         outlookdata        = normpath(filepath, "Core"),
-        outlookAEMO        = normpath(filepath, "Auxiliary/CapacityOutlook2024_Condensed.xlsx"),
-        vpp_cap            = normpath(filepath, "Auxiliary/StorageCapacityOutlook_2024_ISP.xlsx"),
-        vpp_ene            = normpath(filepath, "Auxiliary/StorageEnergyOutlook_2024_ISP.xlsx"),
+        outlookAEMO        = source_path(filepath, spec(:condensed_capacity_outlook)),
+        vpp_cap            = source_path(filepath, spec(:vpp_capacity_outlook)),
+        vpp_ene            = source_path(filepath, spec(:vpp_energy_outlook)),
     )
 end
 


### PR DESCRIPTION
This is refactor of the main `PISP.jl/src` based on the docs (see: https://github.com/ARPST-UniMelb/PISP.jl/pull/73) to make workbook/excel/csv read auditable from outside of `PISP.jl`.

This PR pass checking 1 by 1 identical slicing of `scripts/audit_source_spec_equivalence.jl`.