### PR TITLE
make `ParseISP.jl` `id_gen` deterministic across Julia versions

### DIFF
--- a/src/parameters/general2024ISP.jl
+++ b/src/parameters/general2024ISP.jl
@@ -22,7 +22,13 @@ NEMBUSNAME = OrderedDict(
                         "TAS"   =>  "Tasmania", 
                         "CSA"   =>  "Central South Australia",
                         "SESA"  => "South East South Australia")
-# Buses locations            
+# Frozen bus order for solar/wind id_gen assignment.
+# NOTE:
+#   This is due to bug caused by inconsistent order across Julia versions.
+#   This is currently only impact `LSPV_`, `WIND_`, and retired generators.
+LARGE_SOLAR_BUS_ORDER = ["CQ","VIC","NNSW","SQ","CSA","NQ","SNSW","CNSW","TAS","SESA"]
+LARGE_WIND_BUS_ORDER  = ["CQ","VIC","NNSW","SQ","CSA","NQ","SNSW","CNSW","TAS","SESA","SNW"]
+# Buses locations
 NEMBUSES = OrderedDict(        "NQ"    => [-17.79385, 145.5635],       #1
                         "CQ"    =>  [-22.82420, 149.40361],     #2
                         "GG"    =>  [-23.842948, 151.248803],   #3

--- a/src/parameters/retirements2024ISP.jl
+++ b/src/parameters/retirements2024ISP.jl
@@ -2,17 +2,17 @@
 Reduction2024 = [
             # PROGRESSIVE CHANGE
                 # FLEXIBLE GAS CSA
-            Dict("Quarantine"      => [(1,7,2044,106)]),
+            OrderedDict("Quarantine"      => [(1,7,2044,106)]),
             # STEP CHANGE
                 # FLEXIBLE GAS CSA
-            Dict("Quarantine"      => [(1,7,2044,106)]),
+            OrderedDict("Quarantine"      => [(1,7,2044,106)]),
             # GREEN ENERGY EXPORTS
                 # FLEXIBLE GAS CSA
-            Dict("Quarantine"      => [(1,7,2044,106)]),]
+            OrderedDict("Quarantine"      => [(1,7,2044,106)]),]
 
 # GENERATION RETIREMENTS FOR CDP 14
 Retirements2024 = [
-                    Dict(# PROGRESSIVE CHANGE ID 1
+                    OrderedDict(# PROGRESSIVE CHANGE ID 1
                     #BLACK COAL
                         #NQ
                         #CQ
@@ -102,7 +102,7 @@ Retirements2024 = [
                         "Tamar Valley Peaking" => [(1,7,2050,0)]#x1 PROGRESSIVE 
                     ),
 
-                    Dict(# STEP CHANGE ID 2
+                    OrderedDict(# STEP CHANGE ID 2
                     #BLACK COAL
                         #NQ
                         #CQ
@@ -192,7 +192,7 @@ Retirements2024 = [
                         "Tamar Valley Peaking" => [(1,7,2050,0)]#x1
                     ),
 
-                    Dict(# GREEN ENERGY EXPORTS ID 3
+                    OrderedDict(# GREEN ENERGY EXPORTS ID 3
                     #BLACK COAL
                         #NQ
                         #CQ
@@ -284,3 +284,8 @@ Retirements2024 = [
                     ),
 
 ]
+
+# NOTE:
+#   This is due to bug caused by inconsistent order across Julia versions.
+#   This is currently only impact `LSPV_`, `WIND_`, and retired generators.
+RETIREMENT_ORDER_2024 = ["Vales Point B", "Barcaldine Power Station", "Callide C", "Mt Piper", "Yarwun Cogen", "Tamar Valley Peaking", "Yallourn W", "Bell Bay Three", "Uranquinty", "Gladstone", "Newport", "Ladbroke Grove", "Townsville Power Station", "Jeeralang B", "Kogan Creek", "Tarong", "Dry Creek GT", "Braemar", "Tarong North", "Braemar 2 Power Station", "Eraring", "Darling Downs", "Bolivar Power Station", "Mt Stuart", "Loy Yang B", "Bayswater", "Bairnsdale", "Somerton", "Port Lincoln GT", "Torrens Island B", "Pelican Point", "Oakey Power Station", "Smithfield Energy Facility", "Condamine A", "Tallawarra", "Mortlake", "Barker Inlet Power Station", "Loy Yang A Power Station", "Roma", "Mintaro GT", "Callide B", "Tamar Valley Combined Cycle", "Snapper Point Power Station", "Swanbank E GT", "Stanwell", "Osborne", "Snuggery", "Jeeralang A", "Millmerran", "Hallett GT"]

--- a/src/parsers/ParseISP-2024parser.jl
+++ b/src/parsers/ParseISP-2024parser.jl
@@ -1386,10 +1386,10 @@ function gen_retirements(ts, tv)
     ppmaxid = isempty(tv.gen_pmax) ? 0 : maximum(tv.gen_pmax.id)
 
     for scid in keys(ParseISP.ID2SCE)
-        for unit in ParseISP.Retirements2024[scid]
-            genid = gent[gent[!,:name] .== unit[1], :id_gen][1]
-            for ndata in unit[2]
-                pnid+=1; 
+        for name in ParseISP.RETIREMENT_ORDER_2024
+            genid = gent[gent[!,:name] .== name, :id_gen][1]
+            for ndata in ParseISP.Retirements2024[scid][name]
+                pnid+=1;
                 push!(tv.gen_n, [pnid, genid, scid, DateTime(ndata[3],ndata[2],ndata[1]), ndata[4]])
             end
         end
@@ -1713,7 +1713,7 @@ function gen_pmax_solar(tc::ParseISPtimeConfig, ts::ParseISPtimeStatic, tv::Pars
     # println(REZ_BUS)
 
     genid = Dict()
-    for st in setdiff(keys(ParseISP.NEMBUSNAME),["GG", "SNW"]) ## Buses with no large-scale solar projects or REZ are not considered
+    for st in ParseISP.LARGE_SOLAR_BUS_ORDER
         gid += 1
         bus_data = bust[bust[!,:name] .== st, :]
         bus_id = bus_data[!, :id_bus][1]    
@@ -1757,7 +1757,7 @@ function gen_pmax_solar(tc::ParseISPtimeConfig, ts::ParseISPtimeStatic, tv::Pars
         
         y = ms < 7 ? yr - 1 : yr
 
-        for st in setdiff(keys(ParseISP.NEMBUSNAME),["GG", "SNW"]) # Buses with no large-scale solar projects are not considered
+        for st in ParseISP.LARGE_SOLAR_BUS_ORDER
 
             REZs = REZ_BUS[(REZ_BUS[!,Symbol("ISP Sub-region")] .== st),:ID]
             REZSUM = REZ_BUS[(REZ_BUS[!,Symbol("ISP Sub-region")] .== st),[:ID,:Name,Symbol("ISP Sub-region")]]
@@ -1906,7 +1906,7 @@ function gen_pmax_wind(tc::ParseISPtimeConfig, ts::ParseISPtimeStatic, tv::Parse
     REZ_BUS = ParseISP.read_xlsx_with_header(ispdata24, ISP2024_RENEWABLE_ENERGY_ZONES_SOURCE)
 
     genid = Dict()
-    for st in setdiff(keys(ParseISP.NEMBUSNAME),["GG"]) ## Buses with no large-scale solar projects or REZ are not considered
+    for st in ParseISP.LARGE_WIND_BUS_ORDER
         gid += 1
         bus_data = bust[bust[!,:name] .== st, :]
         bus_id = bus_data[!, :id_bus][1]    
@@ -1953,7 +1953,7 @@ function gen_pmax_wind(tc::ParseISPtimeConfig, ts::ParseISPtimeStatic, tv::Parse
         
         y = ms < 7 ? yr - 1 : yr
 
-        for st in setdiff(keys(ParseISP.NEMBUSNAME),["GG"]) # Buses with no large-scale wind are not considered
+        for st in ParseISP.LARGE_WIND_BUS_ORDER
 
             REZs = REZ_BUS[(REZ_BUS[!,Symbol("ISP Sub-region")] .== st),:ID]
             REZSUM = REZ_BUS[(REZ_BUS[!,Symbol("ISP Sub-region")] .== st),[:ID,:Name,Symbol("ISP Sub-region")]]


### PR DESCRIPTION
This is a split from https://github.com/ARPST-UniMelb/ParseISP.jl/pull/81 that modify only the `src/`.